### PR TITLE
Add extended mailto information

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
+- 280: extend business manager mailto link with pre-filled subject and email body
 - 268: add assignment creation form with services, org picker, and inline skill creation
 - 268: add success toast notification after assignment creation
 

--- a/wies/core/jinja2/parts/assignment_panel_content.html
+++ b/wies/core/jinja2/parts/assignment_panel_content.html
@@ -89,10 +89,9 @@
           {% else %}
             {{ panel_data.assignment.owner.name }}
           {% endif %}
-          {% if panel_data.assignment.owner.email %}
+          {% if panel_data.owner_mailto_href %}
             <br>
-            <a href="mailto:{{ panel_data.assignment.owner.email }}"
-               class="rvo-link">{{ panel_data.assignment.owner.email }}</a>
+            <a href="{{ panel_data.owner_mailto_href }}" class="rvo-link">{{ panel_data.assignment.owner.email }}</a>
           {% endif %}
         </dd>
       {% endif %}

--- a/wies/core/views.py
+++ b/wies/core/views.py
@@ -1,5 +1,6 @@
 import logging
 import tempfile
+import urllib.parse
 from collections import Counter
 from datetime import date, timedelta
 from pathlib import Path
@@ -215,6 +216,23 @@ def _build_assignment_panel_data(assignment, request, breadcrumb_base):
         {**get_org_breadcrumb(rel.organization, breadcrumb_base), "role": rel.role} for rel in [*primary, *involved]
     ]
 
+    owner_mailto_href = ""
+    if assignment.owner and assignment.owner.email:
+        opdracht_url = request.build_absolute_uri(reverse("assignment-list") + f"?opdracht={assignment.id}")
+        subject = urllib.parse.quote(f"Informatieverzoek over opdracht {assignment.name}")
+        body_lines = [
+            f"Beste {assignment.owner.name},",
+            "",
+            f"Ik zag deze opdracht {opdracht_url} op WIES."
+            + (f" De beschrijving is: {assignment.extra_info}" if assignment.extra_info else ""),
+            "",
+            "Kun je me hier meer informatie over geven?",
+        ]
+        consultant_name = getattr(getattr(request.user, "colleague", None), "name", "")
+        body_lines += ["", "Met vriendelijke groet,", "", consultant_name]
+        body = urllib.parse.quote("\n".join(body_lines))
+        owner_mailto_href = f"mailto:{assignment.owner.email}?subject={subject}&body={body}"
+
     return {
         "panel_content_template": "parts/assignment_panel_content.html",
         "panel_title": assignment.name,
@@ -223,6 +241,7 @@ def _build_assignment_panel_data(assignment, request, breadcrumb_base):
         "team_members": team_members,
         "user_can_edit": user_can_edit_assignment(request.user, assignment),
         "owner_url": _build_panel_url(request, collega=assignment.owner.id) if assignment.owner else "",
+        "owner_mailto_href": owner_mailto_href,
         "org_breadcrumbs": org_breadcrumbs,
     }
 


### PR DESCRIPTION
Summary

- Pre-fill the business manager mailto link with a subject (assignment name) and a draft email body
- Body includes a greeting, a direct link to the assignment on WIES, and the assignment description if available

Test plan

- Open an assignment with a business manager email (e.g. /opdrachten/?opdracht=1)
- Click the email link and verify the subject and body are pre-filled
- Verify the link in the email body points to the correct assignment
- Test with an assignment that has no description, verify the "Opdrachtbeschrijving" line is omitted