### PR TITLE
Add logout support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@ This files lists the changes during the lifetime of this project.
 - 309: add sidebar footer with links to privacy, toegankelijkheid, contact and GitHub
 - 309: add privacy, toegankelijkheid and contact pages
 - 309: make sidebar sticky so footer stays visible during scroll
+- 58: add logout button to profile and no-access pages
+- 58: on logout, clear Django session and redirect to Keycloak's OIDC end_session endpoint
+- 58: force credential re-prompt after logout via a session-scoped post_logout cookie + prompt=login, preventing silent re-auth until the browser is closed
 
 ## 2026-04-23
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -161,6 +161,9 @@ AUTH_USER_MODEL = "rijksauth.User"
 
 AUTH_NO_ACCESS_URL = "/geen-toegang/"
 
+OIDC_ID_TOKEN_SESSION_KEY = "oidc_id_token"  # noqa: S105 (hardcoded-password) — session key name, not a secret
+OIDC_POST_LOGOUT_COOKIE_NAME = "wies_post_logout"
+
 # Allowed email domains for ODI users
 ALLOWED_EMAIL_DOMAINS = ["@rijksoverheid.nl", "@minbzk.nl"]
 

--- a/wies/core/jinja2/no_access.html
+++ b/wies/core/jinja2/no_access.html
@@ -27,11 +27,9 @@
       Mogelijk ben je ingelogd met het e-mailadres van een opdrachtgever. Log uit en probeer het opnieuw met je ODI-account.
       </c-alert>
     {% endif %}
-    {# TODO: Activeer uitlogknop zodra volledige SSO-Rijk logout flow is geïmplementeerd (https://github.com/RijksICTGilde/wies/issues/58)
     <form action="{{ url('logout') }}" method="post">
-        {{ get_csrf_hidden_input(request) }}
-        <c-button kind="secondary" type="submit">Uitloggen en opnieuw proberen</c-button>
+      {{ get_csrf_hidden_input(request) }}
+      <c-button kind="secondary" type="submit">Uitloggen en opnieuw proberen</c-button>
     </form>
-    #}
   </main>
 {% endblock content %}

--- a/wies/core/jinja2/no_access.html
+++ b/wies/core/jinja2/no_access.html
@@ -27,7 +27,9 @@
       Mogelijk ben je ingelogd met het e-mailadres van een opdrachtgever. Log uit en probeer het opnieuw met je ODI-account.
       </c-alert>
     {% endif %}
-    <form action="{{ url('logout') }}" method="post">
+    <form action="{{ url('logout') }}"
+          method="post"
+          class="rvo-margin-block-start--md">
       {{ get_csrf_hidden_input(request) }}
       <c-button kind="secondary" type="submit">Uitloggen en opnieuw proberen</c-button>
     </form>

--- a/wies/core/jinja2/user_profile.html
+++ b/wies/core/jinja2/user_profile.html
@@ -11,12 +11,18 @@
   <div class="profile-page rvo-layout-column rvo-layout-gap--xl">
     {# Profile info #}
     <section class="rvo-layout-column rvo-layout-gap--md">
+      <c-grid division="1fr auto" gap="md">
       <div class="rvo-layout-row rvo-layout-gap--md rvo-layout-align--center">
         <img alt="Profielfoto van {{ user.get_full_name() }}"
              src="{{ static('img/placeholder-avatar.svg') }}"
              class="profile-avatar" />
         <h1 class="utrecht-heading-1 rvo-heading rvo-heading--no-margin">Mijn profiel</h1>
       </div>
+      <form method="post" action="{{ url('logout') }}">
+        {{ get_csrf_hidden_input(request) }}
+        <c-button kind="primary" type="submit">Uitloggen</c-button>
+      </form>
+      </c-grid>
       <dl class="rvo-data-list profile-data-list">
         <dt>Voornaam</dt>
         <dd>

--- a/wies/rijksauth/tests/test_views.py
+++ b/wies/rijksauth/tests/test_views.py
@@ -157,7 +157,7 @@ class AuthViewsTest(TestCase):
 
     @patch("wies.rijksauth.views._get_oidc")
     def test_login_after_logout_forces_reauth(self, mock_get_oidc):
-        """With the post-logout cookie set, login passes prompt=login and clears the cookie."""
+        """With the post-logout cookie set, login passes prompt=login and keeps the cookie."""
         mock_get_oidc.return_value.authorize_redirect.return_value = HttpResponse(status=302)
         self.client.cookies["wies_post_logout"] = "1"
 
@@ -165,7 +165,46 @@ class AuthViewsTest(TestCase):
 
         call_args = mock_get_oidc.return_value.authorize_redirect.call_args
         assert call_args.kwargs.get("prompt") == "login"
-        # Cookie is cleared on the response (Set-Cookie with empty value + expired date).
+        # Cookie is NOT cleared on the login redirect — only after the full auth
+        # round-trip completes, so abandoning the Keycloak flow doesn't silently
+        # re-enable silent SSO on the next attempt.
+        assert "wies_post_logout" not in response.cookies
+
+    @patch("wies.rijksauth.views._get_oidc")
+    def test_auth_clears_post_logout_cookie_on_success(self, mock_get_oidc):
+        """After a successful auth round-trip, the post-logout cookie is cleared."""
+        mock_get_oidc.return_value.authorize_access_token.return_value = {
+            "id_token": "fake-id-token",
+            "userinfo": {
+                "sub": "test_sso_user",
+                "given_name": "Test",
+                "family_name": "User",
+                "email": "test@rijksoverheid.nl",
+            },
+        }
+        self.client.cookies["wies_post_logout"] = "1"
+
+        response = self.client.get(reverse("auth"))
+
+        assert response.cookies["wies_post_logout"].value == ""
+        assert response.cookies["wies_post_logout"]["max-age"] == 0
+
+    @patch("wies.rijksauth.views._get_oidc")
+    def test_auth_clears_post_logout_cookie_on_no_access(self, mock_get_oidc):
+        """After auth completes for a non-whitelisted user, the cookie is still cleared."""
+        mock_get_oidc.return_value.authorize_access_token.return_value = {
+            "id_token": "fake-id-token",
+            "userinfo": {
+                "sub": "unknown_user",
+                "given_name": "Unknown",
+                "family_name": "Person",
+                "email": "unknown@rijksoverheid.nl",
+            },
+        }
+        self.client.cookies["wies_post_logout"] = "1"
+
+        response = self.client.get(reverse("auth"))
+
         assert response.cookies["wies_post_logout"].value == ""
         assert response.cookies["wies_post_logout"]["max-age"] == 0
 

--- a/wies/rijksauth/tests/test_views.py
+++ b/wies/rijksauth/tests/test_views.py
@@ -24,12 +24,13 @@ class AuthViewsTest(TestCase):
     def test_auth_endpoint_success_whitelisted_user(self, mock_get_oidc):
         """Test successful SSO login for whitelisted Colleague"""
         mock_get_oidc.return_value.authorize_access_token.return_value = {
+            "id_token": "fake-id-token",
             "userinfo": {
                 "sub": "test_sso_user",
                 "given_name": "Test",
                 "family_name": "User",
                 "email": "test@rijksoverheid.nl",
-            }
+            },
         }
 
         response = self.client.get(reverse("auth"))
@@ -45,12 +46,13 @@ class AuthViewsTest(TestCase):
     def test_auth_endpoint_failure_non_whitelisted_user(self, mock_get_oidc):
         """Test SSO login for non-whitelisted user redirects to no-access"""
         mock_get_oidc.return_value.authorize_access_token.return_value = {
+            "id_token": "fake-id-token",
             "userinfo": {
                 "sub": "unknown_user",
                 "given_name": "Unknown",
                 "family_name": "Person",
                 "email": "unknown@rijksoverheid.nl",
-            }
+            },
         }
 
         response = self.client.get(reverse("auth"))
@@ -62,16 +64,20 @@ class AuthViewsTest(TestCase):
         # Should NOT create session
         assert "_auth_user_id" not in self.client.session
 
+        # Should stash the id_token so the no-access logout button can end Keycloak's session
+        assert self.client.session.get("oidc_id_token") == "fake-id-token"
+
     @patch("wies.rijksauth.views._get_oidc")
     def test_auth_endpoint_session_creation(self, mock_get_oidc):
         """Test that successful auth creates proper session"""
         mock_get_oidc.return_value.authorize_access_token.return_value = {
+            "id_token": "fake-id-token",
             "userinfo": {
                 "sub": "test_sso_user",
                 "given_name": "Test",
                 "family_name": "User",
                 "email": "test@rijksoverheid.nl",
-            }
+            },
         }
 
         # Verify no session before auth
@@ -84,20 +90,18 @@ class AuthViewsTest(TestCase):
         assert int(self.client.session["_auth_user_id"]) == self.colleague.pk
 
     def test_logout_clears_session(self):
-        """Test that logout clears the session"""
-        # Login the user first
+        """Without an id_token in the session, logout falls back to the local login page."""
         self.client.force_login(self.colleague)
         assert "_auth_user_id" in self.client.session
 
-        # Logout
         response = self.client.get(reverse("logout"))
 
-        # Should redirect to home/login
         assert response.status_code == 302
         assert response.url == "/inloggen/"
+        # Post-logout cookie is set even on the local fallback path.
+        assert response.cookies["wies_post_logout"].value == "1"
 
-        # Session should be cleared (new session will be created but without user)
-        # Accessing a protected page should now redirect to login
+        # Session should be cleared
         protected_response = self.client.get(reverse("home"))
         assert protected_response.status_code == 302
         assert protected_response.url.startswith("/inloggen/")
@@ -106,9 +110,32 @@ class AuthViewsTest(TestCase):
         """Test logout works gracefully when user is not logged in"""
         response = self.client.get(reverse("logout"))
 
-        # Should redirect to home without error (no login requirement)
         assert response.status_code == 302
         assert response.url == "/inloggen/"
+
+    @patch("wies.rijksauth.views._get_oidc")
+    def test_logout_redirects_to_keycloak_end_session(self, mock_get_oidc):
+        """With an id_token stored, logout redirects to Keycloak's end_session endpoint."""
+        mock_get_oidc.return_value.load_server_metadata.return_value = {
+            "end_session_endpoint": "https://kc.example/realms/wies/protocol/openid-connect/logout",
+        }
+        self.client.force_login(self.colleague)
+        session = self.client.session
+        session["oidc_id_token"] = "fake-id-token"  # noqa: S105 (hardcoded-password) — test fixture, not a real token
+        session.save()
+
+        response = self.client.get(reverse("logout"))
+
+        assert response.status_code == 302
+        assert response.url.startswith("https://kc.example/realms/wies/protocol/openid-connect/logout?")
+        assert "id_token_hint=fake-id-token" in response.url
+        assert "post_logout_redirect_uri=" in response.url
+        assert "%2Finloggen%2F" in response.url
+        # Local session is cleared
+        assert "_auth_user_id" not in self.client.session
+        # Post-logout cookie is set so the next login forces credential re-entry.
+        assert response.cookies["wies_post_logout"].value == "1"
+        assert response.cookies["wies_post_logout"]["samesite"] == "Lax"
 
     @patch("wies.rijksauth.views._get_oidc")
     def test_login_redirects_directly_to_keycloak(self, mock_get_oidc):
@@ -124,6 +151,23 @@ class AuthViewsTest(TestCase):
         call_args = mock_get_oidc.return_value.authorize_redirect.call_args
         redirect_uri = call_args[0][1]  # Second positional argument
         assert "/auth/" in redirect_uri
+
+        # Without the post-logout cookie, silent SSO is preserved.
+        assert "prompt" not in call_args.kwargs
+
+    @patch("wies.rijksauth.views._get_oidc")
+    def test_login_after_logout_forces_reauth(self, mock_get_oidc):
+        """With the post-logout cookie set, login passes prompt=login and clears the cookie."""
+        mock_get_oidc.return_value.authorize_redirect.return_value = HttpResponse(status=302)
+        self.client.cookies["wies_post_logout"] = "1"
+
+        response = self.client.get(reverse("login"))
+
+        call_args = mock_get_oidc.return_value.authorize_redirect.call_args
+        assert call_args.kwargs.get("prompt") == "login"
+        # Cookie is cleared on the response (Set-Cookie with empty value + expired date).
+        assert response.cookies["wies_post_logout"].value == ""
+        assert response.cookies["wies_post_logout"]["max-age"] == 0
 
     @patch("wies.rijksauth.views._get_oidc")
     def test_failed_login_stores_email_in_session(self, mock_get_oidc):

--- a/wies/rijksauth/views.py
+++ b/wies/rijksauth/views.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+from urllib.parse import urlencode
 
 from authlib.integrations.django_client import OAuth
 from django.conf import settings
@@ -13,6 +14,10 @@ from django.urls import reverse, reverse_lazy
 from .services.events import create_auth_event
 
 logger = logging.getLogger(__name__)
+
+OIDC_ID_TOKEN_SESSION_KEY = "oidc_id_token"  # noqa: S105 (hardcoded-password) — session key name, not a secret
+
+POST_LOGOUT_COOKIE_NAME = "wies_post_logout"
 
 oauth = OAuth()
 
@@ -31,9 +36,18 @@ def _get_oidc():
 
 @login_not_required
 def login(request):
-    """Redirect directly to Keycloak for authentication"""
     redirect_uri = request.build_absolute_uri(reverse_lazy("auth"))
-    return _get_oidc().authorize_redirect(request, redirect_uri)
+    # If the user just logged out, force Keycloak to re-prompt for credentials.
+    # The upstream SSO-Rijk broker chain dead-ends at BZK's terminal logout page,
+    # so Keycloak's session stays alive after logout and would otherwise silently re-auth.
+    kwargs = {}
+    post_logout = request.COOKIES.get(POST_LOGOUT_COOKIE_NAME)
+    if post_logout:
+        kwargs["prompt"] = "login"
+    response = _get_oidc().authorize_redirect(request, redirect_uri, **kwargs)
+    if post_logout:
+        response.delete_cookie(POST_LOGOUT_COOKIE_NAME, path="/")
+    return response
 
 
 @login_not_required
@@ -43,17 +57,58 @@ def auth(request):
     user = auth_authenticate(request, username=userinfo["sub"], email=userinfo["email"])
     if user:
         auth_login(request, user)
+        # Keep the id_token so logout can end the upstream Keycloak/SSO session.
+        request.session[OIDC_ID_TOKEN_SESSION_KEY] = oidc_response.get("id_token")
         logger.info("login successful, access granted")
         create_auth_event(user.email, "Login.success")
         return redirect(request.build_absolute_uri(reverse("home")))
 
     logger.info("login not successful, access denied")
+    # Stash the id_token so the logout button on the no-access page can end
+    # the upstream Keycloak session (otherwise Keycloak re-logs the same user).
+    request.session[OIDC_ID_TOKEN_SESSION_KEY] = oidc_response.get("id_token")
     request.session["failed_login_email"] = userinfo["email"]
     return redirect(settings.AUTH_NO_ACCESS_URL)
 
 
 @login_not_required
 def logout(request):
+    id_token = request.session.get(OIDC_ID_TOKEN_SESSION_KEY)
     if request.user and request.user.is_authenticated:
         auth_logout(request)
-    return redirect(reverse("login"))
+
+    end_session_url = _build_end_session_url(request, id_token)
+    response = redirect(end_session_url) if end_session_url else redirect(reverse("login"))
+    # Session cookie (max_age=None): persists until the browser is closed, matching
+    # BZK's own "sluit je browser" guidance. Cleared explicitly on the next login.
+    response.set_cookie(
+        POST_LOGOUT_COOKIE_NAME,
+        "1",
+        max_age=None,
+        path="/",
+        httponly=True,
+        samesite="Lax",
+        secure=request.is_secure(),
+    )
+    return response
+
+
+def _build_end_session_url(request, id_token: str | None) -> str | None:
+    """Return the Keycloak end_session URL that also terminates SSO-Rijk, or None."""
+    if not id_token:
+        return None
+    try:
+        metadata = _get_oidc().load_server_metadata()
+    except Exception:  # noqa: BLE001 - any discovery failure means local logout only
+        logger.warning("OIDC discovery failed, skipping upstream logout", exc_info=True)
+        return None
+    end_session_endpoint = metadata.get("end_session_endpoint")
+    if not end_session_endpoint:
+        return None
+    params = urlencode(
+        {
+            "id_token_hint": id_token,
+            "post_logout_redirect_uri": request.build_absolute_uri(reverse("login")),
+        }
+    )
+    return f"{end_session_endpoint}?{params}"

--- a/wies/rijksauth/views.py
+++ b/wies/rijksauth/views.py
@@ -15,10 +15,6 @@ from .services.events import create_auth_event
 
 logger = logging.getLogger(__name__)
 
-OIDC_ID_TOKEN_SESSION_KEY = "oidc_id_token"  # noqa: S105 (hardcoded-password) — session key name, not a secret
-
-POST_LOGOUT_COOKIE_NAME = "wies_post_logout"
-
 oauth = OAuth()
 
 
@@ -41,13 +37,9 @@ def login(request):
     # The upstream SSO-Rijk broker chain dead-ends at BZK's terminal logout page,
     # so Keycloak's session stays alive after logout and would otherwise silently re-auth.
     kwargs = {}
-    post_logout = request.COOKIES.get(POST_LOGOUT_COOKIE_NAME)
-    if post_logout:
+    if request.COOKIES.get(settings.OIDC_POST_LOGOUT_COOKIE_NAME):
         kwargs["prompt"] = "login"
-    response = _get_oidc().authorize_redirect(request, redirect_uri, **kwargs)
-    if post_logout:
-        response.delete_cookie(POST_LOGOUT_COOKIE_NAME, path="/")
-    return response
+    return _get_oidc().authorize_redirect(request, redirect_uri, **kwargs)
 
 
 @login_not_required
@@ -58,31 +50,38 @@ def auth(request):
     if user:
         auth_login(request, user)
         # Keep the id_token so logout can end the upstream Keycloak/SSO session.
-        request.session[OIDC_ID_TOKEN_SESSION_KEY] = oidc_response.get("id_token")
+        request.session[settings.OIDC_ID_TOKEN_SESSION_KEY] = oidc_response.get("id_token")
         logger.info("login successful, access granted")
         create_auth_event(user.email, "Login.success")
-        return redirect(request.build_absolute_uri(reverse("home")))
+        response = redirect(request.build_absolute_uri(reverse("home")))
+    else:
+        logger.info("login not successful, access denied")
+        # Stash the id_token so the logout button on the no-access page can end
+        # the upstream Keycloak session (otherwise Keycloak re-logs the same user).
+        request.session[settings.OIDC_ID_TOKEN_SESSION_KEY] = oidc_response.get("id_token")
+        request.session["failed_login_email"] = userinfo["email"]
+        response = redirect(settings.AUTH_NO_ACCESS_URL)
 
-    logger.info("login not successful, access denied")
-    # Stash the id_token so the logout button on the no-access page can end
-    # the upstream Keycloak session (otherwise Keycloak re-logs the same user).
-    request.session[OIDC_ID_TOKEN_SESSION_KEY] = oidc_response.get("id_token")
-    request.session["failed_login_email"] = userinfo["email"]
-    return redirect(settings.AUTH_NO_ACCESS_URL)
+    # Clear the post-logout cookie only after the upstream auth round-trip completes,
+    # so abandoning the Keycloak flow (e.g. opening another tab) doesn't silently
+    # re-enable silent SSO on the next login attempt.
+    if request.COOKIES.get(settings.OIDC_POST_LOGOUT_COOKIE_NAME):
+        response.delete_cookie(settings.OIDC_POST_LOGOUT_COOKIE_NAME, path="/")
+    return response
 
 
 @login_not_required
 def logout(request):
-    id_token = request.session.get(OIDC_ID_TOKEN_SESSION_KEY)
+    id_token = request.session.get(settings.OIDC_ID_TOKEN_SESSION_KEY)
     if request.user and request.user.is_authenticated:
         auth_logout(request)
 
     end_session_url = _build_end_session_url(request, id_token)
     response = redirect(end_session_url) if end_session_url else redirect(reverse("login"))
     # Session cookie (max_age=None): persists until the browser is closed, matching
-    # BZK's own "sluit je browser" guidance. Cleared explicitly on the next login.
+    # BZK's own "sluit je browser" guidance. Cleared after the next completed auth round-trip.
     response.set_cookie(
-        POST_LOGOUT_COOKIE_NAME,
+        settings.OIDC_POST_LOGOUT_COOKIE_NAME,
         "1",
         max_age=None,
         path="/",


### PR DESCRIPTION
## Summary
- Adds logout buttons to profile and no-access pages.
- Clears the Django session and redirects to Keycloak's OIDC `end_session_endpoint` to initiate SSO-Rijk logout.
- Sets a session-scoped `wies_post_logout` cookie on logout; on the next login, if the cookie is present, passes `prompt=login` to force credential re-entry.

## Why the cookie workaround
SSO-Rijk's logout cascade dead-ends at SSC-ICT's terminal "sluit je browser" page and never returns a SAML `LogoutResponse`, so Keycloak's session survives the logout. Without the cookie, returning to Wies after logout silently re-authenticates the same account, blocking the account-picker. Full analysis in [#58](https://github.com/RijksICTGilde/wies/issues/58#issuecomment-4311236986).

## Proposed Test plan
- [x] Log in, click logout, return to the app in the same browser, verify Keycloak shows the login screen (not silent SSO).
- [x] Close browser, reopen, verify first visit silent-SSOs as normal.
- [x] Test logout from the no-access page.
