### PR TITLE
UX verbeteringen: renames, card layouts en inline edit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ This files lists the changes during the lifetime of this project.
 ## unreleased
 
 - 342: fix "Nieuwe gebruiker" form silently failing on duplicate e-mail — error is now shown inline next to the e-mailveld (regressie van #322)
+- 341: Add placement panel: clicking a row in "Wie zit waar?" now shows placement-specific info (role, description, period) instead of the generic colleague profile
 - 341: UX improvements for assignment detail panel: text buttons, compact team cards, floating toast on save
 - 341: Rename "Vacatures" to "Aanvragen" throughout the UI
 - 341: UX improvements for the assignment create form: rename "Diensten" to "Rollen", clarify labels and help text

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,12 @@ This files lists the changes during the lifetime of this project.
 ## unreleased
 
 - 342: fix "Nieuwe gebruiker" form silently failing on duplicate e-mail — error is now shown inline next to the e-mailveld (regressie van #322)
+- 341: UX improvements for assignment detail panel: text buttons, compact team cards, floating toast on save
+- 341: Rename "Vacatures" to "Aanvragen" throughout the UI
+- 341: UX improvements for the assignment create form: rename "Diensten" to "Rollen", clarify labels and help text
+- 341: Prevent side panel and modals from closing on backdrop click while editing
+- 341: Make entire inline-edit row clickable (not just the pencil icon)
+- 341: Fix sidebar filter scroll: dynamically adjust max-height for header offset
 - 324: replace raw HTML with JRC components across templates and include roos.css
 - 324: add sortable Tot column to placement table
 - 336: fix user CSV import to accept `;` delimiter and files with UTF-8 BOM
@@ -335,5 +341,3 @@ This files lists the changes during the lifetime of this project.
 - add syncing between exact and wies colleagues
 
 ## demo-2025-08-04
-
-...

--- a/wies/core/editables/service.py
+++ b/wies/core/editables/service.py
@@ -22,4 +22,4 @@ class ServiceEditables(EditableSet):
     period_source = Editable(label="Periode gebaseerd op")
     specific_start_date = Editable(label="Specifieke startdatum")
     specific_end_date = Editable(label="Specifieke einddatum")
-    status = Editable(label="Status")
+    status = Editable(label="Status", display=lambda s: s.get_status_display())

--- a/wies/core/forms.py
+++ b/wies/core/forms.py
@@ -202,9 +202,9 @@ class ServiceForm(RvoFormMixin, forms.Form):
         required=False,
         empty_label=" ",
     )
-    description = forms.CharField(label="Omschrijving", max_length=500, required=False)
+    description = forms.CharField(label="Toelichting", max_length=500, required=False)
     new_skill_name = forms.CharField(label="Naam nieuwe rol", max_length=30, required=False)
-    is_filled = forms.BooleanField(label="Rol ingevuld", required=False)
+    is_filled = forms.BooleanField(label="Consultant bekend", required=False)
     colleague = forms.ModelChoiceField(
         label="Consultant",
         queryset=Colleague.objects.order_by("name"),
@@ -240,7 +240,7 @@ class ServiceForm(RvoFormMixin, forms.Form):
         is_filled = cleaned_data.get("is_filled")
         colleague = cleaned_data.get("colleague")
         if is_filled and not colleague:
-            self.add_error("colleague", "Selecteer een consultant als de rol is ingevuld.")
+            self.add_error("colleague", "Selecteer een consultant.")
         # "Rol ingevuld" is the authoritative on/off for the placement.
         # The UI hides (not clears) the colleague select when the
         # checkbox is off, so the posted colleague id would otherwise

--- a/wies/core/jinja2/assignment_create.html
+++ b/wies/core/jinja2/assignment_create.html
@@ -21,11 +21,11 @@
     <div class="rvo-form">
       <div class="rvo-layout-column rvo-layout-gap--md">
         <div class="rvo-layout-column rvo-layout-gap--sm">
-          <c-link href="{{ url('assignment-list') }}" icon="terug" iconPlacement="before" noUnderline>Terug naar vacatures</c-link>
+          <c-link href="{{ url('assignment-list') }}" icon="terug" iconPlacement="before" noUnderline>Terug naar aanvragen</c-link>
           <div>
             <c-h1>Opdracht invoeren</c-h1>
             <p>
-              Voer hier de gegevens in van een opdracht. Dit formulier kan gebruikt worden voor nieuwe opdrachten, bestaande opdrachten en vacatures.
+              Voer hier de gegevens in van een opdracht. Dit formulier kan gebruikt worden voor nieuwe opdrachten, bestaande opdrachten en aanvragen.
             </p>
           </div>
         </div>
@@ -47,7 +47,7 @@
               {% for error in form.organizations.errors %}<c-alert kind="error">{{ error }}</c-alert>{% endfor %}
               {{ form.organizations.as_widget() }}
             {% endcall %}
-            {% call fieldset("Diensten", distanced=false, gap="xs", id="diensten", hint="voeg minimaal 1 dienst toe") %}
+            {% call fieldset("Rollen", distanced=false, gap="xs", id="diensten", hint="voeg minimaal 1 rol toe") %}
               {% with formset=service_formset, extra_errors=form.non_field_errors() %}
                 {% include "parts/assignment_services_form.html" %}
               {% endwith %}

--- a/wies/core/jinja2/base.html
+++ b/wies/core/jinja2/base.html
@@ -62,5 +62,21 @@
     </div>
     {% block panel %}
     {% endblock panel %}
+    <script>
+      // Dynamically set --sidebar-offset so sticky sidebar max-height
+      // accounts for the header visible above the fold.
+      (function() {
+        const sidebar = document.querySelector('.sidebar');
+        if (!sidebar) return;
+        const update = () => {
+          const rect = sidebar.getBoundingClientRect();
+          const offset = Math.max(0, rect.top);
+          document.documentElement.style.setProperty('--sidebar-offset', offset + 'px');
+        };
+        update();
+        window.addEventListener('scroll', update, {passive: true});
+        window.addEventListener('resize', update);
+      })();
+    </script>
   </body>
 </html>

--- a/wies/core/jinja2/parts/assignment_card_rows.html
+++ b/wies/core/jinja2/parts/assignment_card_rows.html
@@ -1,37 +1,45 @@
 {% for assignment in object_list %}
-  <c-card outline padding="md" class="assignment-card assignment-card--clickable" tabindex="0" role="link" aria-label="{{ assignment.name }}" hx-get="{{ assignment.panel_url }}" hx-target="#side_panel-container" onkeydown="if(event.key==='Enter')htmx.trigger(this,'click')" style="cursor: pointer">
-  <div class="assignment-card__header">
-    <c-h3 noMargins class="assignment-card__title">{{ assignment.name }}</c-h3>
-  </div>
-  {% if assignment.org_breadcrumb %}
-    <span class="rvo-text">
-      <c-icon icon="basis-kantoorgebouw" size="md" color="grijs-700" />
-      {{ assignment.org_breadcrumb.label }}
-    </span>
-  {% endif %}
-  {% if assignment.start_date or assignment.end_date %}
-    <span class="assignment-card__meta-item rvo-text rvo-text--subtle">
-      <c-icon icon="kalender" size="md" />
-      {{ assignment.start_date|datum_nl("N Y") }}
-      {% if assignment.end_date %}- {{ assignment.end_date|datum_nl("N Y") }}{% endif %}
-    </span>
-  {% endif %}
-  {% if assignment.services_with_skills %}
-    <div class="assignment-card__tags"
-         role="list"
-         aria-label="Gezochte rollen">
-      {% for service in assignment.services_with_skills[:3] %}
-        <span role="listitem"><c-tag>{{ service.skill.name }}</c-tag></span>
-      {% endfor %}
-      {% if assignment.services_with_skills|length > 3 %}
-        <span role="listitem"><c-tag>+{{ assignment.services_with_skills|length - 3 }} meer</c-tag></span>
+  <div class="assignment-card assignment-card--clickable"
+       tabindex="0"
+       role="link"
+       aria-label="{{ assignment.name }}"
+       hx-get="{{ assignment.panel_url }}"
+       hx-target="#side_panel-container"
+       onkeydown="if(event.key==='Enter')htmx.trigger(this,'click')">
+    <div class="assignment-card__name">
+      <strong class="assignment-card__title truncate" title="{{ assignment.name }}">{{ assignment.name }}</strong>
+    </div>
+    <div class="assignment-card__body">
+      <div class="assignment-card__info">
+        {% if assignment.org_breadcrumb %}
+          <span class="truncate" title="{{ assignment.org_breadcrumb.label }}">{{ assignment.org_breadcrumb.label }}</span>
+        {% endif %}
+        {% if assignment.start_date or assignment.end_date %}
+          <span class="icon-text-inline">
+            <c-icon icon="kalender" size="md" color="grijs-700" />
+            {{ assignment.start_date|datum_nl("N Y") }}
+            {% if assignment.end_date %}- {{ assignment.end_date|datum_nl("N Y") }}{% endif %}
+          </span>
+        {% endif %}
+      </div>
+      {% if assignment.services_with_skills %}
+        <hr class="assignment-card__divider">
+        <div class="assignment-card__tags"
+             role="list"
+             aria-label="Gezochte rollen">
+          {% for service in assignment.services_with_skills[:3] %}
+            <span role="listitem"><c-tag type="info">{{ service.skill.name }}</c-tag></span>
+          {% endfor %}
+          {% if assignment.services_with_skills|length > 3 %}
+            <span role="listitem"><c-tag type="info">+{{ assignment.services_with_skills|length - 3 }} meer</c-tag></span>
+          {% endif %}
+        </div>
       {% endif %}
     </div>
-  {% endif %}
-  </c-card>
+  </div>
 {% else %}
   <div class="assignment-card-grid__empty">
-    <span class="rvo-text--italic rvo-text--subtle">Geen vacatures gevonden.</span>
+    <span class="rvo-text--italic rvo-text--subtle">Geen aanvragen gevonden.</span>
   </div>
 {% endfor %}
 {% if next_page_url %}

--- a/wies/core/jinja2/parts/assignment_org_modal.html
+++ b/wies/core/jinja2/parts/assignment_org_modal.html
@@ -1,6 +1,6 @@
 <dialog id="assignmentOrgPickerModal"
         class="modal-dialog modal-dialog--wide"
-        closedby="any">
+        closedby="none">
   <div class="modal-content">
     <div class="modal-header">
       <c-h2>Selecteer opdrachtgever(s)</c-h2>

--- a/wies/core/jinja2/parts/assignment_panel_content.html
+++ b/wies/core/jinja2/parts/assignment_panel_content.html
@@ -29,7 +29,7 @@
          {% if panel_data.show_updates_tab %}class="rvo-tabs__panel" role="tabpanel" aria-labelledby="tab-gegevens" tabindex="0"{% endif %}>
       <div class="rvo-layout-column rvo-layout-gap--lg">
         <section>
-          <c-h2>Opdracht gegevens</c-h2>
+          <c-h2>Opdrachtgegevens</c-h2>
           <c-data-list>
           <dt>Opdracht naam</dt>
           <dd>
@@ -81,8 +81,17 @@
           </c-data-list>
         </section>
         <section>
-          <c-h2>Team</c-h2>
-          {{ inline_edit(panel_data.assignment, "services") }}
+          <div class="section-header">
+            <c-h2>Team ({{ panel_data.assignment.services.count() }})</c-h2>
+            {% set a = panel_data.assignment %}
+            {% set ie_target = "inline-edit-assignment-" ~ a.pk ~ "-services" %}
+            {% if has_permission(Verb.UPDATE, a, request.user, AssignmentEditables.services) %}
+              <c-button kind="tertiary" icon="bewerken" iconPlacement="after" hx-get="{{ url('inline-edit', args=[a._meta.model_name, a.pk, 'services']) }}?edit=true" hx-target="#{{ ie_target }}" hx-swap="outerHTML">
+              Team bewerken
+              </c-button>
+            {% endif %}
+          </div>
+          {{ inline_edit(a, "services", hide_edit_button=true) }}
         </section>
       </div>
     </div>

--- a/wies/core/jinja2/parts/assignment_services_form.html
+++ b/wies/core/jinja2/parts/assignment_services_form.html
@@ -9,7 +9,7 @@
        surfaces alongside formset-level errors.
 #}
 <p class="rvo-text--sm">
-  Vul je een consultant in? Dan is de dienst direct bezet. Laat je het veld leeg, dan wordt de dienst als vacature geplaatst.
+  Voeg één of meer rollen toe. Is de consultant al bekend? Vink dan "Consultant bekend" aan om deze direct te koppelen.
 </p>
 {{ formset.management_form }}
 {% set _extra_errors = extra_errors if extra_errors is defined else [] %}
@@ -34,6 +34,6 @@
         class="rvo-button rvo-button--tertiary rvo-button--size-sm rvo-button--icon-before">
   <span class="utrecht-icon rvo-icon rvo-icon-plus rvo-icon--md rvo-link__icon--before"
         role="img"
-        aria-label="Dienst toevoegen"></span>
-  Dienst toevoegen
+        aria-label="Rol toevoegen"></span>
+  Rol toevoegen
 </button>

--- a/wies/core/jinja2/parts/client_modal.html
+++ b/wies/core/jinja2/parts/client_modal.html
@@ -1,6 +1,6 @@
 <dialog id="clientModal"
         class="modal-dialog modal-dialog--wide"
-        closedby="any">
+        closedby="none">
   <div class="modal-content">
     <div class="modal-header">
       <c-h2>Selecteer opdrachtgever(s)</c-h2>

--- a/wies/core/jinja2/parts/colleague_assignment_cards.html
+++ b/wies/core/jinja2/parts/colleague_assignment_cards.html
@@ -11,6 +11,8 @@
           <strong class="assignment-card__title">{{ assignment.name }}</strong>
           {% if assignment.historical %}
             <c-tag type="default" class="assignment-tag--completed">Afgelopen</c-tag>
+          {% elif assignment.show_read_more %}
+            <span class="assignment-card__read-more">Lees meer ›</span>
           {% elif assignment.start_date or assignment.end_date %}
             <span class="icon-text-inline">
               <c-icon icon="kalender" size="md" color="grijs-700" />
@@ -25,6 +27,14 @@
                 <c-icon icon="basis-kantoorgebouw" size="md" color="grijs-700" />
                 {{ assignment.organization }}
               </span>
+            {% endif %}
+            {% if assignment.team_members %}
+              <div class="assignment-card__team">
+                <span class="rvo-text--subtle rvo-text--sm">Collega's op deze opdracht:</span>
+                {% for member in assignment.team_members %}
+                  <div class="user-avatar user-avatar--sm" title="{{ member }}">{{ member|first|upper }}</div>
+                {% endfor %}
+              </div>
             {% endif %}
             <div class="assignment-card__subtitle">
               {% for tag in assignment.tags %}<c-tag type="default">{{ tag.skill if tag is mapping else tag }}</c-tag>{% endfor %}

--- a/wies/core/jinja2/parts/colleague_assignment_cards.html
+++ b/wies/core/jinja2/parts/colleague_assignment_cards.html
@@ -1,43 +1,47 @@
 {# Shared assignment card list for colleague panel and profile page.
    Expects: assignments (list), hx_target (string) #}
 {% if assignments %}
-  <div class="rvo-layout-column rvo-layout-gap--sm">
+  <div class="rvo-layout-column rvo-layout-gap--xs">
     {% for assignment in assignments %}
       <a href="{{ assignment.assignment_url }}"
          hx-get="{{ assignment.assignment_url }}"
          hx-target="{{ hx_target }}"
-         class="rvo-card rvo-card--outline rvo-card--padding--md clickable-row panel-card-link">
-        <div class="rvo-card__content">
-          <div class="colleague-assignment-header">
-            <span class="colleague-assignment-name">
-              <strong>{{ assignment.name }}</strong>
-              {% if assignment.organization %}
-                <span class="icon-text-inline">
-                  <c-icon icon="basis-kantoorgebouw" size="md" color="grijs-700" />
-                  {{ assignment.organization }}
-                </span>
-              {% endif %}
+         class="assignment-card">
+        <div class="assignment-card__name">
+          <strong class="assignment-card__title">{{ assignment.name }}</strong>
+          {% if assignment.historical %}
+            <c-tag type="default" class="assignment-tag--completed">Afgelopen</c-tag>
+          {% elif assignment.start_date or assignment.end_date %}
+            <span class="icon-text-inline">
+              <c-icon icon="kalender" size="md" color="grijs-700" />
+              {{ assignment.start_date|datum_nl("N y") }} - {{ assignment.end_date|datum_nl("N y") }}
             </span>
-            {% if assignment.start_date or assignment.end_date %}
-              <span class="colleague-assignment-date">
-                <c-icon icon="kalender" size="md" color="grijs-700" />
-                {{ assignment.start_date|datum_nl("N y") }} - {{ assignment.end_date|datum_nl("N y") }}
+          {% endif %}
+        </div>
+        <div class="assignment-card__body">
+          <div class="assignment-card__info">
+            {% if assignment.organization %}
+              <span class="icon-text-inline">
+                <c-icon icon="basis-kantoorgebouw" size="md" color="grijs-700" />
+                {{ assignment.organization }}
               </span>
             {% endif %}
-          </div>
-          <div class="rvo-layout-row colleague-assignment-tags">
-            <div>
-              {% for tag in assignment.tags %}
-                <div class="service-description-line">
-                  {{ tag.skill if tag is mapping else tag }}
-                  {% if tag is mapping and tag.description %}· <span class="rvo-text--subtle">{{ tag.description }}</span>{% endif %}
-                </div>
-              {% endfor %}
+            <div class="assignment-card__subtitle">
+              {% for tag in assignment.tags %}<c-tag type="default">{{ tag.skill if tag is mapping else tag }}</c-tag>{% endfor %}
             </div>
-            {% if assignment.historical %}<c-tag type="default" class="assignment-tag--completed">Afgelopen</c-tag>{% endif %}
           </div>
+          {% set descriptions = [] %}
+          {% for tag in assignment.tags %}
+            {% if tag is mapping and tag.description %}
+              {% set _ = descriptions.append(tag.description) %}
+            {% endif %}
+          {% endfor %}
+          {% if descriptions %}
+            <hr class="assignment-card__divider">
+            {% for desc in descriptions %}<div class="rvo-text--italic">{{ desc }}</div>{% endfor %}
+          {% endif %}
           {% if assignment.privacy_warning_text %}
-            <div class="rvo-layout-row rvo-layout-gap--xs rvo-layout-align--center">
+            <div class="assignment-card__privacy">
               <c-icon icon="hangslot-dicht" size="sm" color="grijs-700" />
               <span class="rvo-text--subtle rvo-text--xs">{{ assignment.privacy_warning_text }}</span>
             </div>

--- a/wies/core/jinja2/parts/filter_and_card_container.html
+++ b/wies/core/jinja2/parts/filter_and_card_container.html
@@ -4,7 +4,7 @@
   <div class="layout__main__header">
     <!-- Row 1: Title + Search -->
     <div class="header-row header-row--between">
-      <c-h1 noMargins>Vacatures</c-h1>
+      <c-h1 noMargins>Aanvragen</c-h1>
       <div class="header-actions">
         <!-- Mobile filter toggle -->
         <c-button kind="secondary" size="md" icon="trechter" iconPlacement="before" type="button" class="mobile-filter-toggle" data-toggle-filters>

--- a/wies/core/jinja2/parts/generic_form_modal.html
+++ b/wies/core/jinja2/parts/generic_form_modal.html
@@ -1,4 +1,4 @@
-<dialog id="{{ modal_element_id }}" class="modal-dialog" closedby="any">
+<dialog id="{{ modal_element_id }}" class="modal-dialog" closedby="none">
   <div class="modal-content">
     <div class="modal-header">
       <c-h2>{{ modal_title }}</c-h2>

--- a/wies/core/jinja2/parts/inline_edit/display.html
+++ b/wies/core/jinja2/parts/inline_edit/display.html
@@ -1,7 +1,7 @@
 {# Wrapper stays classless so HTMX swaps between display/form/collection
   modes don't toggle layout classes on the target. The display layout
   (value + pencil, flex row) lives on the inner block. #}
-<div id="{{ target }}">
+<div id="{{ target }}"{% if saved %} data-just-saved{% endif %}>
   <div class="editable-field-display">
     {% if alert %}
       <div class="rvo-alert rvo-alert--{{ alert.kind }} rvo-margin-block-end--xs"
@@ -9,20 +9,17 @@
         <p>{{ alert.message }}</p>
       </div>
     {% endif %}
-    <div class="editable-field-display__value">
+    <div class="editable-field-display__value"
+         {% if user_can_edit and not hide_edit_button %} hx-get="{{ edit_url }}?edit=true" hx-target="#{{ target }}" hx-swap="outerHTML" role="button" tabindex="0" style="cursor: pointer" {% endif %}>
       {% if display and display.template %}
         {% include display.template %}
       {% else %}
         <span>{{ display.text if display else "" }}</span>
       {% endif %}
     </div>
-    {% if user_can_edit %}
-      {# Icon-only trigger — a raw <button> with RVO icon span. c-button
-        doesn't support a truly label-less button (its default label
-        renders as "Button" when content is empty), so we stay with this
-        widely-used pattern. #}
+    {% if user_can_edit and not hide_edit_button %}
       <button type="button"
-              class="edit-icon-button{% if saved %} edit-icon-button--just-saved{% endif %}"
+              class="edit-icon-button"
               hx-get="{{ edit_url }}?edit=true"
               hx-target="#{{ target }}"
               hx-swap="outerHTML"
@@ -30,7 +27,6 @@
         <span class="utrecht-icon rvo-icon rvo-icon-bewerken rvo-icon--md edit-icon-button__pencil"
               role="img"
               aria-label="Bewerk"></span>
-        {% if saved %}<span class="edit-icon-button__check" role="status" aria-label="Opgeslagen">✓</span>{% endif %}
       </button>
     {% endif %}
   </div>

--- a/wies/core/jinja2/parts/inline_edit/display.html
+++ b/wies/core/jinja2/parts/inline_edit/display.html
@@ -1,7 +1,7 @@
 {# Wrapper stays classless so HTMX swaps between display/form/collection
   modes don't toggle layout classes on the target. The display layout
-  (value + pencil, flex row) lives on the inner block. #}
-<div id="{{ target }}"{% if saved %} data-just-saved{% endif %}>
+  (clickable value row + optional pencil, flex row) lives on the inner block. #}
+<div id="{{ target }}">
   <div class="editable-field-display">
     {% if alert %}
       <div class="rvo-alert rvo-alert--{{ alert.kind }} rvo-margin-block-end--xs"

--- a/wies/core/jinja2/parts/menubar.html
+++ b/wies/core/jinja2/parts/menubar.html
@@ -1,7 +1,7 @@
 {# Menubar met navigatie - binnen layout__body grid #}
 {% set menu_items = [
   {"label": "Wie zit waar?", "link": url('home'), "active": request.path == '/'},
-  {"label": "Vacatures", "link": url('assignment-list'), "active": '/opdrachten/' in request.path},
+  {"label": "Aanvragen", "link": url('assignment-list'), "active": '/opdrachten/' in request.path},
 ] %}
 {% if user.is_authenticated %}
   {% set menu_items = menu_items + [

--- a/wies/core/jinja2/parts/placement_panel_content.html
+++ b/wies/core/jinja2/parts/placement_panel_content.html
@@ -1,0 +1,59 @@
+{% set colleague = panel_data.colleague %}
+{% set service = panel_data.service %}
+{% set placement = panel_data.placement %}
+<div class="rvo-layout-column rvo-layout-gap--lg">
+  <section>
+    <div class="card card--horizontal">
+      <div class="card__image">
+        <img alt="Profielfoto van {{ colleague.name }}"
+             src="{{ static('img/placeholder-avatar.svg') }}" />
+      </div>
+      <div class="card__content">
+        <c-h3 noMargins>{{ colleague.name }}</c-h3>
+        <div class="rvo-layout-row rvo-layout-gap--xs rvo-layout-align--center">
+          <c-icon icon="mail" size="md" color="hemelblauw" />
+          <c-link href="mailto:{{ colleague.email }}">{{ colleague.email }}</c-link>
+        </div>
+      </div>
+    </div>
+  </section>
+  {% set labels = colleague.labels.all() %}
+  {% if labels %}
+    <div class="rvo-layout-row rvo-layout-gap--sm label-badge-list">
+      {% for label in labels %}
+        <c-tag type="default" class="label-badge" style="background-color: {{ label.category.color }}">{{ label.name }}</c-tag>
+      {% endfor %}
+    </div>
+  {% endif %}
+  <section>
+    <c-h2 style="margin-bottom: var(--rvo-space-sm);">Informatie over huidige opdracht</c-h2>
+    {% with assignments=[panel_data.assignment_card], hx_target="#side_panel-content" %}
+      {% include "parts/colleague_assignment_cards.html" %}
+    {% endwith %}
+  </section>
+  <section>
+    <c-data-list>
+    <dt>Rol van {{ colleague.name.split()[0] }}</dt>
+    <dd>
+      {{ inline_edit(service, "skill") }}
+    </dd>
+    <dt>Omschrijving</dt>
+    <dd>
+      {{ inline_edit(service, "description") }}
+    </dd>
+    <dt>Periode</dt>
+    <dd>
+      {% if placement.start_date or placement.end_date %}
+        <span class="icon-text-inline">
+          <c-icon icon="kalender" size="md" color="grijs-700" />
+          {{ placement.start_date|datum_nl("j F Y") if placement.start_date else "–" }}
+          t/m
+          {{ placement.end_date|datum_nl("j F Y") if placement.end_date else "heden" }}
+        </span>
+      {% else %}
+        <span class="rvo-text--italic">Geen periode ingesteld</span>
+      {% endif %}
+    </dd>
+    </c-data-list>
+  </section>
+</div>

--- a/wies/core/jinja2/parts/placement_table_rows.html
+++ b/wies/core/jinja2/parts/placement_table_rows.html
@@ -1,5 +1,5 @@
 {% for placement in object_list %}
-  <c-table-row class="clickable-row" hx-get="{{ placement.colleague_url }}" hx-target="#side_panel-container">
+  <c-table-row class="clickable-row" hx-get="{{ placement.panel_url }}" hx-target="#side_panel-container">
   <c-table-cell>
   <div class="user-table-cell">
     <div class="user-avatar">{{ placement.colleague.name|first|upper }}</div>

--- a/wies/core/jinja2/parts/service_row.html
+++ b/wies/core/jinja2/parts/service_row.html
@@ -4,7 +4,7 @@
   <div class="service-new-skill" style="display: none">{{ svc_form.new_skill_name.as_field_group() }}</div>
   {{ svc_form.description.as_field_group() }}
   <div class="service-row__checkbox-line">
-    <label class="rvo-checkbox">{{ svc_form.is_filled }} Rol ingevuld</label>
+    <label class="rvo-checkbox">{{ svc_form.is_filled }} Consultant bekend</label>
   </div>
   <div class="service-colleague-field" style="display: none">
     <div class="utrecht-form-field">

--- a/wies/core/jinja2/parts/side_panel.html
+++ b/wies/core/jinja2/parts/side_panel.html
@@ -1,6 +1,6 @@
 <dialog class="rvo-dialog rvo-dialog--wit rvo-dialog--inset-inline-end"
         aria-label="{{ panel_data.panel_title }}"
-        closedby="any"
+        closedby="none"
         id="side_panel">
   <div class="side-panel__header">
     <c-button kind="tertiary" size="md" icon="terug" iconPlacement="before" type="button" @click="panelBack()">

--- a/wies/core/jinja2/parts/user_form_modal.html
+++ b/wies/core/jinja2/parts/user_form_modal.html
@@ -1,6 +1,6 @@
 <dialog id="{{ modal_element_id }}"
         class="modal-dialog modal-dialog--wide"
-        closedby="any">
+        closedby="none">
   <div class="modal-content">
     <div class="modal-header">
       <c-h2>{{ modal_title }}</c-h2>

--- a/wies/core/jinja2/parts/user_table_rows.html
+++ b/wies/core/jinja2/parts/user_table_rows.html
@@ -16,18 +16,13 @@
               justify-content: space-between">
     <div style="display: flex; gap: 0.25rem; flex-wrap: wrap;">
       {% for group in user.groups.all() %}
-        <span class="rvo-text rvo-text--sm"
-              style="background-color: #e6f0ff;
-                     color: #154273;
-                     padding: 0.125rem 0.5rem;
-                     border-radius: 0.25rem;
-                     white-space: nowrap">
-          {% if group.name == 'Business Development Manager' %}
-            BDM
-          {% else %}
-            {{ group.name }}
-          {% endif %}
-        </span>
+        <c-tag type="info">
+        {% if group.name == 'Business Development Manager' %}
+          BDM
+        {% else %}
+          {{ group.name }}
+        {% endif %}
+        </c-tag>
       {% else %}
         <span class="rvo-text rvo-text--sm rvo-text--subtle">-</span>
       {% endfor %}

--- a/wies/core/jinja2/rvo/forms/displays/assignment_services.html
+++ b/wies/core/jinja2/rvo/forms/displays/assignment_services.html
@@ -17,34 +17,28 @@
     {% for row in value %}
       {% if row.colleague %}
         {% set colleague_url = '/opdrachten/?collega=' ~ row.colleague.id %}
-        <div class="rvo-item-list__item rvo-item-list__item--filled service-row">
-          <a href="{{ colleague_url }}"
-             hx-get="{{ colleague_url }}"
-             hx-target="#side_panel-content"
-             class="service-row__link"
-             title="Bekijk {{ row.colleague.name }}">
+        <div class="rvo-item-list__item rvo-item-list__item--filled">
+          <div class="service-card__name">
             <div class="user-avatar">{{ row.colleague.name|first|upper }}</div>
-            <div class="rvo-item-list__content">
-              <strong>{{ row.colleague.name }}</strong>
-              <div class="service-description-line">{{ row.skill_name }}</div>
-            </div>
-          </a>
-          {# Description lives outside the anchor: it carries its own
-             inline-edit pencil (a consultant placed on this service may
-             rewrite their role description), and a button may not nest
-             inside an <a>. #}
-          <div class="service-row__description">{{ inline_edit(row.service, "description") }}</div>
+            <span>
+              <a href="{{ colleague_url }}"
+                 hx-get="{{ colleague_url }}"
+                 hx-target="#side_panel-content"
+                 class="rvo-link">{{ row.colleague.name }}</a> · {{ row.skill_name }}
+            </span>
+          </div>
+          <div class="service-card__description">{{ inline_edit(row.service, "description") }}</div>
         </div>
       {% else %}
-        <div class="rvo-item-list__item rvo-item-list__item--vacant service-row">
-          <div class="service-row__link">
+        <div class="rvo-item-list__item rvo-item-list__item--vacant">
+          <div class="service-card__name">
             <div class="user-avatar user-avatar--vacant">?</div>
             <div class="rvo-item-list__content">
-              <span class="rvo-text--italic rvo-text--subtle">Openstaand</span>
+              <span class="rvo-text--italic rvo-text--subtle">Aanvraag</span>
               <div class="service-description-line">{{ row.skill_name }}</div>
             </div>
           </div>
-          <div class="service-row__description">{{ inline_edit(row.service, "description") }}</div>
+          <div class="service-card__description">{{ inline_edit(row.service, "description") }}</div>
         </div>
       {% endif %}
     {% endfor %}

--- a/wies/core/static/css/assignment_cards.css
+++ b/wies/core/static/css/assignment_cards.css
@@ -1,7 +1,8 @@
 .assignment-card-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: auto; /* rows sized by subgrid children */
+  gap: 0 1rem;
 }
 
 .assignment-card-grid__empty {
@@ -10,15 +11,14 @@
   padding: 2rem;
 }
 
-.assignment-card {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
+.assignment-card-grid .assignment-card {
+  display: grid;
+  grid-template-rows: subgrid;
+  grid-row: span 2;
+  margin-bottom: 1rem;
 }
 
 .assignment-card--clickable {
-  text-decoration: none;
-  color: inherit;
   cursor: pointer;
   transition: box-shadow 0.15s ease;
 }
@@ -27,26 +27,8 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
 }
 
-.assignment-card__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-
-.assignment-card__title {
-  font-size: 1.05rem;
-}
-
-.assignment-card__meta-item {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-
 .assignment-card__tags {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-bottom: 0.25rem;
 }

--- a/wies/core/static/css/base.css
+++ b/wies/core/static/css/base.css
@@ -161,7 +161,7 @@ body {
   min-width: 0;
   position: sticky;
   top: 0;
-  max-height: 100vh;
+  max-height: calc(100vh - var(--sidebar-offset, 0px));
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--rvo-color-grijs-400, #b4b4b4) transparent;

--- a/wies/core/static/css/side_panel.css
+++ b/wies/core/static/css/side_panel.css
@@ -297,6 +297,25 @@ dialog#side_panel::backdrop {
   border-top: 1px solid var(--rvo-color-grijs-200, #e2e8f0);
 }
 
+.assignment-card__read-more {
+  color: var(--rvo-color-hemelblauw);
+  font-size: var(--rvo-font-size-sm);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.assignment-card:hover .assignment-card__read-more {
+  text-decoration: underline;
+}
+
+.assignment-card__team {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
 .assignment-card__privacy {
   display: flex;
   align-items: center;
@@ -333,6 +352,12 @@ dialog#side_panel::backdrop {
 .service-card__description {
   padding: 0.5rem 0.75rem 0.5rem calc(32px + 1.5rem);
   font-style: italic;
+}
+
+/* Remove misleading hover on team cards (only the name link is clickable) */
+.rvo-item-list__item--filled:hover {
+  border-color: var(--rvo-color-grijs-300, #c5ced6);
+  background: inherit;
 }
 
 /* Completed assignment tag */

--- a/wies/core/static/css/side_panel.css
+++ b/wies/core/static/css/side_panel.css
@@ -190,7 +190,7 @@ dialog#side_panel::backdrop {
   align-items: flex-start;
 }
 
-/* Colleague panel: assignment cards */
+/* Colleague panel: assignment header and date */
 .colleague-assignment-header {
   display: flex;
   justify-content: space-between;
@@ -212,16 +212,127 @@ dialog#side_panel::backdrop {
   gap: 0.5rem;
 }
 
+/* Colleague panel: assignment cards (ux/improvements card layout) */
+.assignment-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--rvo-color-grijs-300, #c5ced6);
+  border-radius: 4px;
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
+}
+
+.assignment-card:hover {
+  border-color: var(--rvo-color-hemelblauw, #007bc7);
+}
+
+.assignment-card__name {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--rvo-color-grijs-100, #f3f4f6);
+  min-width: 0;
+}
+
+.assignment-card:hover .assignment-card__name {
+  background: var(--rvo-color-hemelblauw-150, #f0f6fc);
+}
+
+.assignment-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.assignment-card__info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.assignment-card__info > .icon-text-inline:first-child {
+  min-width: 0;
+}
+
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.assignment-card__info > .icon-text-inline:last-child {
+  flex-shrink: 0;
+}
+
+.assignment-card__title {
+  font-size: 1.1rem;
+}
+
+.assignment-card__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.assignment-card__subtitle {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+}
+
+.assignment-card__divider {
+  margin: 0.25rem 0;
+  border: none;
+  border-top: 1px solid var(--rvo-color-grijs-200, #e2e8f0);
+}
+
+.assignment-card__privacy {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.assignment-card__role {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .rvo-item-list__item {
   display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
-  padding: 0.75rem;
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
   border: 1px solid var(--rvo-color-grijs-300, #c5ced6);
   border-radius: 4px;
   text-decoration: none;
   color: inherit;
   width: 100%;
+  overflow: hidden;
+}
+
+.service-card__name {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--rvo-color-grijs-100, #f3f4f6);
+}
+
+.service-card__description {
+  padding: 0.5rem 0.75rem 0.5rem calc(32px + 1.5rem);
+  font-style: italic;
 }
 
 /* Completed assignment tag */
@@ -324,6 +435,13 @@ dialog#side_panel::backdrop {
   margin-top: 8px;
 }
 
+/* Section header — heading + action link side by side */
+.section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
 /* Editable field styles */
 .editable-field-display {
   display: flex;
@@ -374,68 +492,19 @@ dialog#side_panel::backdrop {
   gap: var(--rvo-space-2xs);
 }
 
-/* Post-save flash: the pencil is briefly replaced by a green check
-   overlaid on top, which fades back to the pencil. Pure CSS — the
-   server re-renders the partial with the `--just-saved` modifier and
-   the animation runs once client-side. */
-.edit-icon-button__check {
-  position: absolute;
-  inset: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--rvo-color-grasgroen, #39870c);
-  font-weight: bold;
-  font-size: 1.1em;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.edit-icon-button--just-saved .edit-icon-button__pencil {
-  animation: inline-edit-pencil-return 1.6s ease-out forwards;
-}
-
-.edit-icon-button--just-saved .edit-icon-button__check {
-  animation: inline-edit-check-flash 1.6s ease-out forwards;
-}
-
-@keyframes inline-edit-check-flash {
-  0% {
-    opacity: 0;
-    transform: scale(0.5);
-  }
-  15% {
-    opacity: 1;
-    transform: scale(1.25);
-  }
-  40% {
-    opacity: 1;
-    transform: scale(1);
-  }
-  80% {
-    opacity: 1;
-    transform: scale(1);
-  }
-  100% {
-    opacity: 0;
-    transform: scale(1);
-  }
-}
-
-@keyframes inline-edit-pencil-return {
-  0%,
-  70% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
+/* Post-save animation keyframes removed — save feedback now uses the
+   floating toast (flash-messages) triggered by the inline-edit-saved
+   HX-Trigger event in inline_edit.js. */
 
 .field-actions {
   display: flex;
+  align-items: center;
   gap: var(--rvo-space-sm);
-  margin-top: var(--rvo-space-md);
+  margin-top: var(--rvo-space-sm);
+}
+
+.field-actions .rvo-button {
+  inline-size: auto;
 }
 
 /* Form field error styling */

--- a/wies/core/static/js/dialog.js
+++ b/wies/core/static/js/dialog.js
@@ -1,7 +1,7 @@
 // HTMX + Dialog integration - hybrid approach
 document.addEventListener("htmx:afterSwap", function (e) {
   // When HTMX loads modal content into a container, find any dialogs and show them
-  const dialogs = e.detail.target.querySelectorAll('dialog[closedby="any"]');
+  const dialogs = e.detail.target.querySelectorAll("dialog[closedby]");
 
   dialogs.forEach(function (dialog) {
     // Auto-show dialog when HTMX loads content
@@ -23,6 +23,19 @@ document.addEventListener("htmx:afterSwap", function (e) {
       });
     });
   });
+});
+
+// ESC key → close topmost modal dialog (closedby="none" blocks native ESC)
+document.addEventListener("keydown", function (e) {
+  if (e.key !== "Escape") return;
+  // Find the topmost open modal dialog (not the side panel, that has its own handler)
+  const dialogs = document.querySelectorAll('dialog[closedby="none"][open]');
+  for (const dialog of dialogs) {
+    if (dialog.id === "side_panel") continue;
+    e.preventDefault();
+    dialog.close();
+    return;
+  }
 });
 
 // Listen for closeModal trigger from server

--- a/wies/core/static/js/inline_edit.js
+++ b/wies/core/static/js/inline_edit.js
@@ -1,8 +1,53 @@
 // Behaviour for inline-edit display partials.
 //
-// Currently: the "Toon meer / Toon minder" toggle on long text fields
-// (e.g. Assignment.extra_info). A delegated listener on document
-// survives HTMX swaps without rebinding.
+// 1. Toast notification on successful save (listens for HX-Trigger: inline-edit-saved).
+// 2. "Toon meer / Toon minder" toggle on long text fields.
+// Both use delegated listeners that survive HTMX swaps.
+
+function showSavedToast() {
+  // Reuse the flash-messages toast pattern from flash_messages.html.
+  const prev = document.getElementById("flash-messages");
+  if (prev) prev.remove();
+
+  const container = document.createElement("div");
+  container.className = "flash-messages";
+  container.id = "flash-messages";
+  container.innerHTML =
+    '<div class="rvo-alert rvo-alert--success rvo-alert--padding-md" role="alert">' +
+    '  <div class="rvo-alert__container">' +
+    '    <span class="utrecht-icon rvo-icon rvo-icon-bevestiging rvo-status-icon rvo-status-icon-bevestiging rvo-icon--xl" role="img" aria-label="Bevestiging"></span>' +
+    '    <div class="rvo-alert-text">Opgeslagen</div>' +
+    "  </div>" +
+    "</div>";
+  // Append to dialog if open (dialogs render in top-layer, above body),
+  // otherwise append to body.
+  const dialog = document.querySelector("dialog[open]");
+  (dialog || document.body).appendChild(container);
+
+  let timeout = setTimeout(
+    () => container.classList.add("flash-messages--hiding"),
+    3000,
+  );
+  container.addEventListener("mouseenter", () => clearTimeout(timeout));
+  container.addEventListener("mouseleave", () => {
+    timeout = setTimeout(
+      () => container.classList.add("flash-messages--hiding"),
+      2000,
+    );
+  });
+  container.addEventListener("animationend", (e) => {
+    if (e.animationName === "flash-fade-out") container.remove();
+  });
+}
+
+// Show toast after successful inline-edit save.
+document.addEventListener("htmx:afterSettle", (event) => {
+  const saved = document.querySelector("[data-just-saved]");
+  if (saved) {
+    saved.removeAttribute("data-just-saved");
+    showSavedToast();
+  }
+});
 
 document.addEventListener("click", (event) => {
   const toggle = event.target.closest(".inline-edit-show-more");

--- a/wies/core/static/js/inline_edit.js
+++ b/wies/core/static/js/inline_edit.js
@@ -41,13 +41,8 @@ function showSavedToast() {
 }
 
 // Show toast after successful inline-edit save.
-document.addEventListener("htmx:afterSettle", (event) => {
-  const saved = document.querySelector("[data-just-saved]");
-  if (saved) {
-    saved.removeAttribute("data-just-saved");
-    showSavedToast();
-  }
-});
+// The view sets HX-Trigger-After-Swap: inline-edit-saved on the response.
+document.addEventListener("inline-edit-saved", () => showSavedToast());
 
 document.addEventListener("click", (event) => {
   const toggle = event.target.closest(".inline-edit-show-more");

--- a/wies/core/static/js/side_panel.js
+++ b/wies/core/static/js/side_panel.js
@@ -32,6 +32,7 @@ function closeSidePanel() {
   const url = new URL(window.location);
   url.searchParams.delete("collega");
   url.searchParams.delete("opdracht");
+  url.searchParams.delete("plaatsing");
   history.replaceState({}, "", url.toString());
 }
 
@@ -40,7 +41,11 @@ function panelBack() {
     const prevUrl = panelStack.pop();
     const url = new URL(prevUrl, window.location.origin);
 
-    if (url.searchParams.has("collega") || url.searchParams.has("opdracht")) {
+    if (
+      url.searchParams.has("collega") ||
+      url.searchParams.has("opdracht") ||
+      url.searchParams.has("plaatsing")
+    ) {
       history.replaceState({}, "", prevUrl);
       _skipNextPush = true;
       swapPanel(prevUrl);
@@ -112,7 +117,9 @@ document.addEventListener("click", function (e) {
 window.addEventListener("popstate", function () {
   const url = new URL(window.location);
   const hasPanel =
-    url.searchParams.has("collega") || url.searchParams.has("opdracht");
+    url.searchParams.has("collega") ||
+    url.searchParams.has("opdracht") ||
+    url.searchParams.has("plaatsing");
   const panel = document.getElementById("side_panel");
 
   if (!hasPanel && panel && panel.open) {

--- a/wies/core/static/js/side_panel.js
+++ b/wies/core/static/js/side_panel.js
@@ -62,18 +62,15 @@ document.addEventListener("DOMContentLoaded", function () {
     document.documentElement.style.overflow = "hidden";
   }
 
-  // ESC key → close (capturing so it works on replaced dialogs)
-  const container = document.getElementById("side_panel-container");
-  if (container) {
-    container.addEventListener(
-      "cancel",
-      function (e) {
-        e.preventDefault();
-        closeSidePanel();
-      },
-      true,
-    );
-  }
+  // ESC key → close (blocked when an inline-edit form is open)
+  document.addEventListener("keydown", function (e) {
+    if (e.key !== "Escape") return;
+    const panel = document.getElementById("side_panel");
+    if (!panel || !panel.open) return;
+    e.preventDefault();
+    if (panel.querySelector("form[hx-post]")) return;
+    closeSidePanel();
+  });
 });
 
 // After HTMX panel swaps: push URL and track in panel stack.
@@ -102,10 +99,11 @@ document.addEventListener("htmx:afterSettle", function (event) {
   }
 });
 
-// Backdrop click → close
+// Backdrop click → close (unless an inline-edit form is open)
 document.addEventListener("click", function (e) {
   const panel = document.getElementById("side_panel");
   if (panel && panel.open && e.target === panel) {
+    if (panel.querySelector("form[hx-post]")) return;
     closeSidePanel();
   }
 });

--- a/wies/core/tests/test_assignment_list.py
+++ b/wies/core/tests/test_assignment_list.py
@@ -18,7 +18,7 @@ User = get_user_model()
 
 
 class AssignmentListViewTest(TestCase):
-    """Tests for the assignment list (vacancy cards) view"""
+    """Tests for the assignment list (aanvragen cards) view"""
 
     def setUp(self):
         self.client = Client()
@@ -35,9 +35,9 @@ class AssignmentListViewTest(TestCase):
         self.skill = Skill.objects.create(name="Python Developer")
         self.skill2 = Skill.objects.create(name="Data Engineer")
 
-        # Vacancy assignment (has unfilled OPEN service → should appear)
+        # Aanvraag assignment (has unfilled OPEN service → should appear)
         self.vacancy = Assignment.objects.create(
-            name="Open Vacature",
+            name="Open Aanvraag",
             start_date=date(2025, 1, 1),
             end_date=date(2025, 12, 31),
             source="wies",
@@ -72,43 +72,43 @@ class AssignmentListViewTest(TestCase):
         assert response.status_code == 302
         assert "/inloggen/" in response.url
 
-    def test_shows_only_vacature_assignments(self):
+    def test_shows_only_aanvraag_assignments(self):
         self.client.force_login(self.auth_user)
         response = self.client.get(self.list_url)
         assert response.status_code == 200
         content = response.content.decode()
-        assert "Open Vacature" in content
+        assert "Open Aanvraag" in content
         assert "Ingevulde Opdracht" not in content
 
     def test_search_filter(self):
         self.client.force_login(self.auth_user)
-        response = self.client.get(self.list_url, {"zoek": "Open Vacature"})
+        response = self.client.get(self.list_url, {"zoek": "Open Aanvraag"})
         content = response.content.decode()
-        assert "Open Vacature" in content
+        assert "Open Aanvraag" in content
 
         response = self.client.get(self.list_url, {"zoek": "nonexistent"})
         content = response.content.decode()
-        assert "Open Vacature" not in content
+        assert "Open Aanvraag" not in content
 
     def test_filter_by_rol(self):
         self.client.force_login(self.auth_user)
         response = self.client.get(self.list_url, {"rol": str(self.skill.id)})
         content = response.content.decode()
-        assert "Open Vacature" in content
+        assert "Open Aanvraag" in content
 
         response = self.client.get(self.list_url, {"rol": str(self.skill2.id)})
         content = response.content.decode()
-        assert "Open Vacature" not in content
+        assert "Open Aanvraag" not in content
 
     def test_filter_by_org(self):
         self.client.force_login(self.auth_user)
         response = self.client.get(self.list_url, {"org_self": str(self.org.id)})
         content = response.content.decode()
-        assert "Open Vacature" in content
+        assert "Open Aanvraag" in content
 
         response = self.client.get(self.list_url, {"org_self": str(self.org2.id)})
         content = response.content.decode()
-        assert "Open Vacature" not in content
+        assert "Open Aanvraag" not in content
 
     def test_htmx_filter_returns_card_container(self):
         self.client.force_login(self.auth_user)

--- a/wies/core/tests/test_inline_edit.py
+++ b/wies/core/tests/test_inline_edit.py
@@ -155,12 +155,8 @@ class InlineEditInfrastructureTest(TestCase):
         resp = self.client.post(self.url, {"name": "Updated name"})
         assert resp.status_code == 200
         self.assertContains(resp, "Updated name")
-        # No big alert banner on the happy path — instead the pencil
-        # button carries a `--just-saved` class that drives a CSS
-        # pencil→checkmark→pencil flash.
-        self.assertNotContains(resp, "rvo-alert--success")
-        self.assertContains(resp, "edit-icon-button--just-saved")
-        self.assertContains(resp, "edit-icon-button__check")
+        # Save feedback is a toast triggered client-side via HX-Trigger.
+        assert resp["HX-Trigger-After-Swap"] == "inline-edit-saved"
         self.assignment.refresh_from_db()
         assert self.assignment.name == "Updated name"
 
@@ -666,14 +662,14 @@ class AssignmentServicesDisplayTest(TestCase):
         self.assertContains(resp, f'href="{expected_href}"')
         self.assertContains(resp, f'hx-get="{expected_href}"')
         self.assertContains(resp, 'hx-target="#side_panel-content"')
-        self.assertContains(resp, f'title="Bekijk {self.colleague.name}"')
+        self.assertContains(resp, self.colleague.name)
         self.assertContains(resp, "rvo-item-list__item--filled")
 
     def test_vacant_row_has_no_link(self):
         resp = self.client.get(self.url + "?cancel=true")
         assert resp.status_code == 200
         self.assertContains(resp, "rvo-item-list__item--vacant")
-        self.assertContains(resp, "Openstaand")
+        self.assertContains(resp, "Aanvraag")
         # Vacant row should not carry an hx-target (only filled anchors do).
         content = resp.content.decode()
         vacant_start = content.index("rvo-item-list__item--vacant")

--- a/wies/core/views.py
+++ b/wies/core/views.py
@@ -11,7 +11,7 @@ from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.models import Group
 from django.core import management
 from django.core.exceptions import ValidationError
-from django.db.models import Case, Exists, OuterRef, Prefetch, Q, Value, When
+from django.db.models import Case, Exists, F, OuterRef, Prefetch, Q, Value, When
 from django.db.models.functions import Concat
 from django.forms.utils import ErrorList
 from django.http import Http404, HttpResponse, QueryDict
@@ -906,7 +906,7 @@ class AssignmentListView(ListView):
                 placements__isnull=True,
             )
         )
-        qs = Assignment.objects.filter(has_unfilled_open_service).order_by("-created_at")
+        qs = Assignment.objects.filter(has_unfilled_open_service).order_by(F("created_at").desc(nulls_last=True))
         search_filter = self.request.GET.get("zoek")
         if search_filter:
             qs = qs.filter(
@@ -2097,7 +2097,7 @@ def assignment_create(request):
         # Check if at least one service has a skill selected (works even when formset is invalid)
         total_forms = min(int(request.POST.get("service-TOTAL_FORMS", 0)), 100)
         has_any_service = any(request.POST.get(f"service-{i}-skill") for i in range(total_forms))
-        services_error = "" if has_any_service else "Voeg minimaal één dienst toe."
+        services_error = "" if has_any_service else "Voeg minimaal één rol toe."
 
         form_valid = form.is_valid()
         formset_valid = service_formset.is_valid()
@@ -2415,7 +2415,7 @@ def _render_inline_edit_display(
     user_can_edit: bool | None = None,
     saved: bool = False,
 ) -> HttpResponse:
-    # `saved=True` triggers the pencil→check flash; `alert` carries a denial warning.
+    # `saved=True` triggers the toast via data-just-saved attribute; `alert` carries a denial warning.
     # On denial, skip the value/display resolution — it can be heavy (e.g. the
     # services collection does a per-row Placement query) and the partial
     # gracefully handles an empty value with the alert banner.
@@ -2440,7 +2440,10 @@ def _render_inline_edit_display(
         "alert": alert,
         "saved": saved,
     }
-    return render(request, "parts/inline_edit/display.html", ctx)
+    response = render(request, "parts/inline_edit/display.html", ctx)
+    if saved:
+        response["HX-Trigger-After-Swap"] = "inline-edit-saved"
+    return response
 
 
 def _render_inline_edit_form(request, editable_set, spec, editables, obj, form) -> HttpResponse:

--- a/wies/core/views.py
+++ b/wies/core/views.py
@@ -2479,7 +2479,7 @@ def _render_inline_edit_display(
     user_can_edit: bool | None = None,
     saved: bool = False,
 ) -> HttpResponse:
-    # `saved=True` triggers the toast via data-just-saved attribute; `alert` carries a denial warning.
+    # `saved=True` triggers the toast via HX-Trigger-After-Swap; `alert` carries a denial warning.
     # On denial, skip the value/display resolution — it can be heavy (e.g. the
     # services collection does a per-row Placement query) and the partial
     # gracefully handles an empty value with the alert banner.
@@ -2502,7 +2502,6 @@ def _render_inline_edit_display(
             user_can_edit if user_can_edit is not None else has_permission(Verb.UPDATE, obj, request.user, spec)
         ),
         "alert": alert,
-        "saved": saved,
     }
     response = render(request, "parts/inline_edit/display.html", ctx)
     if saved:

--- a/wies/core/views.py
+++ b/wies/core/views.py
@@ -116,6 +116,7 @@ def _build_panel_url(request, **overrides):
     params.pop("pagina", None)
     params.pop("collega", None)
     params.pop("opdracht", None)
+    params.pop("plaatsing", None)
     for key, value in overrides.items():
         params[key] = value
     return f"{request.path}?{params.urlencode()}"
@@ -128,6 +129,7 @@ def _build_close_url(request):
     params.pop("pagina", None)
     params.pop("collega", None)
     params.pop("opdracht", None)
+    params.pop("plaatsing", None)
     return f"{request.path}?{params.urlencode()}" if params else request.path
 
 
@@ -448,6 +450,54 @@ def _build_colleague_panel_data(colleague, request):
     }
 
 
+def _build_placement_panel_data(placement, request):
+    """Build panel context for a single placement (colleague-on-assignment view)."""
+    assignment = placement.service.assignment
+    colleague = placement.colleague
+    service = placement.service
+
+    # Build assignment card in the same format as colleague_assignment_cards.html expects
+    primary_org = (
+        AssignmentOrganizationUnit.objects.filter(assignment=assignment, role="PRIMARY")
+        .values_list("organization__name", flat=True)
+        .first()
+    )
+
+    # Active team members on this assignment
+    team_members = list(
+        Placement.objects.filter(
+            service__assignment=assignment,
+        )
+        .select_related("colleague")
+        .values_list("colleague__name", flat=True)
+        .distinct()
+    )
+
+    assignment_card = {
+        "name": assignment.name,
+        "id": assignment.id,
+        "assignment_url": _build_panel_url(request, opdracht=assignment.id),
+        "start_date": None,
+        "end_date": None,
+        "organization": primary_org,
+        "tags": [],
+        "historical": False,
+        "privacy_warning_text": None,
+        "team_members": team_members,
+        "show_read_more": True,
+    }
+
+    return {
+        "panel_content_template": "parts/placement_panel_content.html",
+        "panel_title": f"{colleague.name} - {assignment.name}",
+        "close_url": _build_close_url(request),
+        "placement": placement,
+        "colleague": colleague,
+        "service": service,
+        "assignment_card": assignment_card,
+    }
+
+
 @login_not_required  # page cannot require login because you land on this after unsuccesful login
 def no_access(request):
     email = request.session.pop("failed_login_email", None)
@@ -682,9 +732,12 @@ class PlacementListView(ListView):
             if self.request.headers.get("HX-Target") == "side_panel-container":
                 return ["parts/side_panel.html"]
             if self.request.headers.get("HX-Target") == "side_panel-content":
+                placement_id = self.request.GET.get("plaatsing")
                 colleague_id = self.request.GET.get("collega")
                 assignment_id = self.request.GET.get("opdracht")
 
+                if placement_id:
+                    return ["parts/placement_panel_content.html"]
                 if colleague_id and not assignment_id:
                     return ["parts/colleague_panel_content.html"]
                 if assignment_id:
@@ -699,9 +752,9 @@ class PlacementListView(ListView):
         context = super().get_context_data(**kwargs)
         context["render_filter_fields_oob"] = "HX-Request" in self.request.headers
 
-        # Add colleague URLs to placement objects
+        # Add panel URLs to placement objects
         for placement in context["object_list"]:
-            placement.colleague_url = _build_panel_url(self.request, collega=placement.colleague.id)
+            placement.panel_url = _build_panel_url(self.request, plaatsing=placement.id)
 
         context["filter_target_url"] = reverse("home")
         context["search_field"] = "zoek"
@@ -872,10 +925,21 @@ class PlacementListView(ListView):
         else:
             context["next_page_url"] = None
 
+        placement_id = self.request.GET.get("plaatsing")
         colleague_id = self.request.GET.get("collega")
         assignment_id = self.request.GET.get("opdracht")
 
-        if colleague_id and not assignment_id:
+        if placement_id:
+            try:
+                placement = Placement.objects.select_related(
+                    "colleague",
+                    "service__assignment",
+                    "service__skill",
+                ).get(id=placement_id)
+                context["panel_data"] = _build_placement_panel_data(placement, self.request)
+            except Placement.DoesNotExist:
+                pass
+        elif colleague_id and not assignment_id:
             try:
                 colleague = Colleague.objects.get(id=colleague_id)
                 context["panel_data"] = _build_colleague_panel_data(colleague, self.request)


### PR DESCRIPTION
## Summary

- **Rename "Vacatures" → "Aanvragen"** in menubar, page header, empty state en create form
- **Rename "Openstaand" → "Aanvraag"** in team service cards
- **Rename "Diensten" → "Rollen"** in create form fieldset, hint en add button
- **Rename labels**: "Rol ingevuld" → "Consultant bekend", "Omschrijving" → "Toelichting"
- **Spelling fix**: "Opdracht gegevens" → "Opdrachtgegevens"
- **Aanvragen cards restyled**: header/body structuur met gekleurde achtergrond, 2-koloms grid met subgrid voor gelijke header-hoogtes, blauwe info-tags voor rollen, opdrachtgever + datum op één rij, truncate met ellipsis en tooltip
- **Team panel**: "Team bewerken" knop met team count, naam als link met inline edit beschrijving
- **Collega opdrachten cards**: naam met achtergrond header, rol tags, organisatie en datum rechts uitgelijnd, cursieve beschrijving onder divider
- **Floating toast** als save-feedback i.p.v. check-animatie op potlood-icoon
- **Dialogs sluiten niet meer bij backdrop click** (`closedby="none"` op alle dialogs), ESC via JS met inline-edit guard op side panel
- **Hele inline-edit rij klikbaar**, niet alleen het potlood-icoon
- **c-tag type="info"** voor rollen-tags op gebruikerstabel en aanvragen cards
- **Fix c-button href error**: anchor met button classes i.p.v. ongeldig `href` attribuut
- **Fix assignment list ordering** voor null `created_at` waarden
- **Fix sidebar filter scroll**: dynamisch `max-height` o.b.v. header offset

## Test plan

- [ ] Menubar en page header tonen "Aanvragen"
- [ ] Aanvragen-pagina: 2-koloms grid, gekleurde headers, blauwe info-tags, truncate bij lange namen
- [ ] Opdracht invoeren toont "Rollen" fieldset met "Consultant bekend" checkbox
- [ ] Opdracht side panel: "Team (n)" heading, naam als link, beschrijving met potlood-icoon
- [ ] Team cards tonen "Aanvraag" i.p.v. "Openstaand"
- [ ] Collega side panel: opdrachten cards met achtergrond header, rol tags, organisatie rechts
- [ ] Na inline edit opslaan verschijnt floating toast "Opgeslagen"
- [ ] Backdrop click sluit panel/modals niet; ESC sluit wel (tenzij edit actief)
- [ ] Hele inline-edit waarde-rij is klikbaar om te bewerken
- [ ] Gebruikerstabel toont blauwe info-tags voor rollen
- [ ] Sidebar filters scrollen correct zonder afgeknipte footer
- [ ] Nieuw aangemaakte opdrachten verschijnen bovenaan de lijst