### PR TITLE
docs: update production domain to wies.rijksorganisatieodi.nl

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
-_ ...
+\_ ...
 
 ## 2026-06-01
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Start a Claude Code session in the project root for AI-assisted development with
 
 ## Production
 
-The production version of this app runs on `wies.rijksapp.nl`. It is deployed using the [ZAD platform](zad.rijksapp.nl):
+The production version of this app runs on `wies.rijksorganisatieodi.nl`. It is deployed using the [ZAD platform](zad.rijksapp.nl):
 
 - Hosted on ODC Noord
 - Guarded by SSO-rijk through keycloak + ODI whitelist


### PR DESCRIPTION
Updates the README production URL from the old `wies.rijksapp.nl` to the new domain `wies.rijksorganisatieodi.nl`.

The new domain is a CNAME to `router.rijksapp.nl`, so hosting/deployment (ZAD / ODC Noord) is unchanged — this is a documentation-only change.