### PR TITLE
staff users can now edit assignment, even when no owner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
+- 392: support staff (users in `STAFF_EMAILS`) can now edit assignments, even when not owner
 - 390: reduce the memory footprint of org sync task to approximately half
 
 ## 2026-06-10

--- a/config/jinja2.py
+++ b/config/jinja2.py
@@ -21,7 +21,7 @@ from wies.core.editables import (
 )
 from wies.core.inline_edit.jinja import inline_edit
 from wies.core.permission_engine import Verb, has_permission
-from wies.core.permissions import can_view_staff_page
+from wies.core.permissions import is_staff_member
 from wies.core.services.organizations import get_org_breadcrumb
 from wies.core.services.version import get_app_version
 
@@ -150,7 +150,7 @@ def environment(**options):
             "get_toggle_sort_url": get_toggle_sort_url,
             "get_sort_state": get_sort_state,
             "get_messages": get_messages,
-            "can_view_staff_page": can_view_staff_page,
+            "is_staff_member": is_staff_member,
             "DEBUG": settings.DEBUG,
             "APP_VERSION": get_app_version(),
             "inline_edit": inline_edit,

--- a/wies/core/jinja2/parts/admin_sidebar.html
+++ b/wies/core/jinja2/parts/admin_sidebar.html
@@ -26,7 +26,7 @@
               Labels
             </a>
           </li>
-          {% if can_view_staff_page(user) %}
+          {% if is_staff_member(user) %}
             <li class="rvo-menubar__item">
               <a href="{{ url('staff-dashboard') }}"
                  class="rvo-link rvo-link--with-icon rvo-link--no-underline rvo-link--lintblauw {% if '/statistieken/' in request.path %}menu-item--active{% endif %}">

--- a/wies/core/permissions.py
+++ b/wies/core/permissions.py
@@ -66,8 +66,12 @@ def _can_edit_assignment_text_field(user, assignment) -> bool:
     return has_permission(UPDATE, assignment, user) or _is_placed_on_assignment(user, assignment)
 
 
-def can_view_staff_page(user):
-    """Whether the given user is allowed to access /beheer/statistieken/ and /beheer/database/ (STAFF_EMAILS list)."""
+def is_staff_member(user):
+    """Whether the given user is a member of the support staff cohort (``STAFF_EMAILS``).
+
+    Used both as a page-access gate (``/beheer/statistieken/``, ``/beheer/database/``)
+    and as a per-row edit-permission predicate (e.g. in ``update_assignment``).
+    """
     return user.is_authenticated and user.email.lower() in settings.STAFF_EMAILS
 
 
@@ -76,14 +80,15 @@ def can_view_staff_page(user):
 
 @rule(UPDATE, Assignment)
 def update_assignment(user, a):
-    """Full edit: BM owner of a wies-sourced assignment, or holder of core.change_assignment.
+    """Full edit: BM owner of a wies-sourced assignment, holder of
+    core.change_assignment, or a support-staff member (``STAFF_EMAILS``).
 
     Placed colleagues do NOT pass — they get narrower access via the
     field-level rules for description/extra_info below.
     """
     if not _is_wies_sourced(a):
         return False
-    return _has_change_perm(user, a) or _is_assignment_owner(user, a)
+    return _has_change_perm(user, a) or _is_assignment_owner(user, a) or is_staff_member(user)
 
 
 @rule(UPDATE, Service)

--- a/wies/core/tests/test_assignment_views.py
+++ b/wies/core/tests/test_assignment_views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
 from wies.core.models import Assignment, Colleague, Event, Placement, Service
@@ -224,6 +224,60 @@ class AssignmentEditAttributeTest(TestCase):
         """External-source (otys_iir) assignments are read-only — display
         partial + denial alert, DB unchanged."""
         self.client.force_login(self.user_with_permission)
+
+        response = self.client.post(
+            reverse("inline-edit", args=["assignment", self.external_assignment.id, "name"]),
+            {"name": "Attempted Update"},
+        )
+
+        assert response.status_code == 200
+        self.assertContains(response, "geen rechten")
+        self.external_assignment.refresh_from_db()
+        assert self.external_assignment.name == "External Assignment"
+
+    @override_settings(STAFF_EMAILS=["staff@rijksoverheid.nl"])
+    def test_staff_member_can_edit_assignment_owner(self):
+        """A user in STAFF_EMAILS can edit whole-object fields on an
+        assignment they don't own (issue #392)."""
+        staff_user = User.objects.create_user(
+            email="staff@rijksoverheid.nl",
+            first_name="Staff",
+            last_name="Member",
+        )
+        new_bdm_user = User.objects.create_user(
+            email="bdm2@rijksoverheid.nl",
+            first_name="New",
+            last_name="BDM",
+        )
+        bdm_group, _ = Group.objects.get_or_create(name="Business Development Manager")
+        new_bdm_user.groups.add(bdm_group)
+        new_bdm = Colleague.objects.create(
+            user=new_bdm_user,
+            name="New BDM",
+            email="bdm2@rijksoverheid.nl",
+            source="wies",
+        )
+        self.client.force_login(staff_user)
+
+        response = self.client.post(
+            reverse("inline-edit", args=["assignment", self.assignment.id, "owner"]),
+            {"owner": new_bdm.id},
+        )
+
+        assert response.status_code == 200
+        self.assignment.refresh_from_db()
+        assert self.assignment.owner_id == new_bdm.id
+
+    @override_settings(STAFF_EMAILS=["staff@rijksoverheid.nl"])
+    def test_staff_member_cannot_edit_external_source_assignment(self):
+        """Staff still can't edit non-wies-sourced assignments — the
+        ``_is_wies_sourced`` gate runs before the staff branch."""
+        staff_user = User.objects.create_user(
+            email="staff@rijksoverheid.nl",
+            first_name="Staff",
+            last_name="Member",
+        )
+        self.client.force_login(staff_user)
 
         response = self.client.post(
             reverse("inline-edit", args=["assignment", self.external_assignment.id, "name"]),

--- a/wies/core/tests/test_permissions.py
+++ b/wies/core/tests/test_permissions.py
@@ -6,7 +6,7 @@ lookup) and the production rules in ``permissions.py``.
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
 from wies.core.editables import (
@@ -98,6 +98,34 @@ class AssignmentPermissionRulesTest(_Setup):
         # Refresh so the permissions cache is rebuilt.
         u = User.objects.get(pk=u.pk)
         assert has_permission(Verb.UPDATE, self.assignment, u) is True
+
+
+@override_settings(STAFF_EMAILS=["staff@x.nl"])
+class StaffMemberCanEditAssignmentTest(_Setup):
+    """Users in ``STAFF_EMAILS`` can edit wies-sourced assignments and their
+    chained Service/Placement records (issue #392). External-source
+    assignments stay read-only."""
+
+    def setUp(self):
+        super().setUp()
+        self.staff_user = User.objects.create_user(email="staff@x.nl", first_name="S", last_name="T")
+
+    def test_staff_can_update_assignment(self):
+        assert has_permission(Verb.UPDATE, self.assignment, self.staff_user) is True
+
+    def test_staff_can_update_service(self):
+        assert has_permission(Verb.UPDATE, self.service, self.staff_user) is True
+
+    def test_staff_can_update_placement(self):
+        assert has_permission(Verb.UPDATE, self.placement, self.staff_user) is True
+
+    def test_staff_cannot_update_external_assignment(self):
+        ext = Assignment.objects.create(name="X", owner=self.owner, source="otys_iir")
+        assert has_permission(Verb.UPDATE, ext, self.staff_user) is False
+
+    def test_non_staff_unrelated_user_still_denied(self):
+        # Sanity check that the override doesn't accidentally grant everyone.
+        assert has_permission(Verb.UPDATE, self.assignment, self.unrelated_user) is False
 
 
 class PlacementPermissionTest(_Setup):

--- a/wies/core/views.py
+++ b/wies/core/views.py
@@ -56,7 +56,7 @@ from .models import (
     Service,
     Skill,
 )
-from .permissions import can_view_staff_page
+from .permissions import is_staff_member
 from .querysets import annotate_placement_dates, annotate_usage_counts
 from .services.assignments import create_assignment_from_form, extract_services_data
 from .services.events import create_event
@@ -501,7 +501,7 @@ def no_access(request):
 
 
 def staff_required(view_func):
-    return user_passes_test(can_view_staff_page, login_url="/geen-toegang/")(view_func)
+    return user_passes_test(is_staff_member, login_url="/geen-toegang/")(view_func)
 
 
 @staff_required


### PR DESCRIPTION
te testen door de env var `STAFF_EMAILS` in je `.env` file wel/niet op je mail te zetten

closes #392 