### PR TITLE
Fix opdracht panel bugs: Business Manager link, team period audit, hidden-input warning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
+- 398: bug fixes — Business Manager link no longer breaks the page (#395), team period changes now show in updates (#393), no more HiddenInput widget warnings (#389)
 - ?: ...
 
 ## 2026-06-11

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
-- 398: bug fixes — Business Manager link no longer breaks the page (#395), team period changes now show in updates (#393), no more HiddenInput widget warnings (#389)
+- 398: bug fixes — Business Manager link no longer breaks the page and now survives editing/cancelling (#395), only the pencil icon opens inline edit (links and "Toon meer" no longer trigger edit mode), clicking a team member opens the panel via htmx again instead of a full page reload, team period changes now show in updates (#393), no more HiddenInput widget warnings (#389)
 - 397: fix team-edit "Neem opdrachtperiode over" checkbox rendering as checked for rows whose effective period differs from the assignment
 - ?: ...
 

--- a/wies/core/editables/assignment.py
+++ b/wies/core/editables/assignment.py
@@ -115,20 +115,42 @@ def _fmt_date(value) -> str | None:
     return value.isoformat() if value else None
 
 
+def _service_audit_row(row: dict) -> dict:
+    return {
+        "id": row["id"],
+        "skill_name": row["skill_name"],
+        "colleague_name": row["colleague"].name if row["colleague"] else None,
+        "description": row["description"] or "",
+        # Period included so a period-only edit registers as a change (#393).
+        "has_custom_period": row["has_custom_period"],
+        "start_date": _fmt_date(row["placement_start_date"]),
+        "end_date": _fmt_date(row["placement_end_date"]),
+    }
+
+
 def _services_audit_state(assignment) -> list[dict]:
-    return [
+    return [_service_audit_row(row) for row in _services_initial(assignment)]
+
+
+def placement_audit_row(placement) -> dict:
+    """Audit row for a single placement, shaped like a services-collection
+    row so the same timeline renderer applies. Lets a period edit made
+    directly on a placement (via the profile) show on the opdracht
+    timeline, not only via "Team bewerken" (#393)."""
+    from wies.core.models import Placement  # noqa: PLC0415 — avoids circular import
+
+    service = placement.service
+    return _service_audit_row(
         {
-            "id": row["id"],
-            "skill_name": row["skill_name"],
-            "colleague_name": row["colleague"].name if row["colleague"] else None,
-            "description": row["description"] or "",
-            # Period included so a period-only edit registers as a change (#393).
-            "has_custom_period": row["has_custom_period"],
-            "start_date": _fmt_date(row["placement_start_date"]),
-            "end_date": _fmt_date(row["placement_end_date"]),
+            "id": service.id,
+            "skill_name": service.skill.name if service.skill else "",
+            "colleague": placement.colleague,
+            "description": service.description,
+            "has_custom_period": placement.period_source != Placement.PLACEMENT,
+            "placement_start_date": placement.start_date,
+            "placement_end_date": placement.end_date,
         }
-        for row in _services_initial(assignment)
-    ]
+    )
 
 
 def _service_row_label(row: dict) -> str:
@@ -138,12 +160,14 @@ def _service_row_label(row: dict) -> str:
 
 
 def _period_label(row: dict) -> str:
-    # `has_custom_period` is inverted: truthy means inherited, not custom.
-    if row.get("has_custom_period"):
-        return "volgt opdracht"
     start = _date_nl(row.get("start_date"))
     end = _date_nl(row.get("end_date"))
-    return f"{start or '?'} t/m {end or '?'}"
+    period = f"{start or '?'} t/m {end or '?'}"
+    # `has_custom_period` is inverted: truthy means inherited, not custom.
+    # Show the dates either way so the old period stays visible (#393).
+    if row.get("has_custom_period"):
+        return f"{period} (volgt opdracht)"
+    return period
 
 
 def _date_nl(iso: str | None) -> str | None:
@@ -167,14 +191,14 @@ def _services_render_change(change: dict) -> dict:
     old_period = _period_label(old)
     new_period = _period_label(new)
     if old_period != new_period:
-        return {"text": f"Periode gewijzigd op {new_label}", "old": old_period, "new": new_period}
+        return {"text": f"Periode gewijzigd van {new_label}", "old": old_period, "new": new_period}
     old_desc = old.get("description") or ""
     new_desc = new.get("description") or ""
     if not old_desc:
-        return {"text": f"Toelichting toegevoegd op {new_label}", "new": new_desc}
+        return {"text": f"Toelichting toegevoegd voor {new_label}", "new": new_desc}
     if not new_desc:
-        return {"text": f"Toelichting verwijderd op {new_label}", "old": old_desc}
-    return {"text": f"Toelichting gewijzigd op {new_label}", "old": old_desc, "new": new_desc}
+        return {"text": f"Toelichting verwijderd voor {new_label}", "old": old_desc}
+    return {"text": f"Toelichting gewijzigd voor {new_label}", "old": old_desc, "new": new_desc}
 
 
 def _validate_period(cleaned):

--- a/wies/core/editables/assignment.py
+++ b/wies/core/editables/assignment.py
@@ -3,8 +3,11 @@
 Permissions live in ``wies/core/permission_rules.py``.
 """
 
+import urllib.parse
+
 from django import forms
 from django.db import transaction
+from django.urls import reverse
 
 from wies.core.fields import OrganizationsField
 from wies.core.inline_edit import Editable, EditableCollection, EditableGroup, EditableSet
@@ -15,6 +18,35 @@ from wies.core.services.assignments import apply_services_to_assignment, extract
 def _bdm_queryset():
     # Wrapped in a callable so `choices` evaluates lazily per request.
     return Colleague.objects.filter(user__groups__name="Business Development Manager").order_by("name")
+
+
+def _owner_display_context(assignment, request) -> dict:
+    """Link + mailto for the owner display partial. Derived only from
+    ``assignment``/``request`` (not the current page's GET params) so they
+    survive an inline-edit/cancel re-render on the ``/inline-edit/`` path (#395)."""
+    if not assignment.owner:
+        return {"owner_url": "", "owner_mailto": ""}
+
+    owner_url = reverse("assignment-list") + f"?collega={assignment.owner.id}"
+
+    owner_mailto = ""
+    if assignment.owner.email:
+        opdracht_url = request.build_absolute_uri(reverse("assignment-list") + f"?opdracht={assignment.id}")
+        subject = urllib.parse.quote(f"Informatieverzoek over opdracht {assignment.name}")
+        body_lines = [
+            f"Beste {assignment.owner.name},",
+            "",
+            f"Ik zag deze opdracht {opdracht_url} op WIES."
+            + (f" De beschrijving is: {assignment.extra_info}" if assignment.extra_info else ""),
+            "",
+            "Kun je me hier meer informatie over geven?",
+        ]
+        consultant_name = getattr(getattr(request.user, "colleague", None), "name", "")
+        body_lines += ["", "Met vriendelijke groet,", "", consultant_name]
+        body = urllib.parse.quote("\n".join(body_lines))
+        owner_mailto = f"mailto:{assignment.owner.email}?subject={subject}&body={body}"
+
+    return {"owner_url": owner_url, "owner_mailto": owner_mailto}
 
 
 def _organizations_initial(assignment):
@@ -248,6 +280,7 @@ class AssignmentEditables(EditableSet):
         error_messages={"required": "Selecteer een business manager."},
         audit_state=lambda c: c.name if c else None,
         display="rvo/forms/displays/assignment_owner.html",
+        display_context=_owner_display_context,
     )
 
     period = EditableGroup(

--- a/wies/core/editables/assignment.py
+++ b/wies/core/editables/assignment.py
@@ -110,6 +110,11 @@ def _save_services(assignment, formset):
     apply_services_to_assignment(assignment, services_data)
 
 
+def _fmt_date(value) -> str | None:
+    """ISO string for JSON-serialisable audit state (dates aren't JSON-native)."""
+    return value.isoformat() if value else None
+
+
 def _services_audit_state(assignment) -> list[dict]:
     return [
         {
@@ -117,6 +122,10 @@ def _services_audit_state(assignment) -> list[dict]:
             "skill_name": row["skill_name"],
             "colleague_name": row["colleague"].name if row["colleague"] else None,
             "description": row["description"] or "",
+            # Period included so a period-only edit registers as a change (#393).
+            "has_custom_period": row["has_custom_period"],
+            "start_date": _fmt_date(row["placement_start_date"]),
+            "end_date": _fmt_date(row["placement_end_date"]),
         }
         for row in _services_initial(assignment)
     ]
@@ -126,6 +135,23 @@ def _service_row_label(row: dict) -> str:
     skill = row.get("skill_name") or "?"
     name = row.get("colleague_name")
     return f"{skill} ({name if name else 'open'})"
+
+
+def _period_label(row: dict) -> str:
+    # `has_custom_period` is inverted: truthy means inherited, not custom.
+    if row.get("has_custom_period"):
+        return "volgt opdracht"
+    start = _date_nl(row.get("start_date"))
+    end = _date_nl(row.get("end_date"))
+    return f"{start or '?'} t/m {end or '?'}"
+
+
+def _date_nl(iso: str | None) -> str | None:
+    """ISO yyyy-mm-dd → Dutch dd-mm-yyyy for timeline display."""
+    if not iso:
+        return None
+    y, m, d = iso.split("-")
+    return f"{d}-{m}-{y}"
 
 
 def _services_render_change(change: dict) -> dict:
@@ -138,6 +164,10 @@ def _services_render_change(change: dict) -> dict:
     new_label = _service_row_label(new)
     if old_label != new_label:
         return {"text": f"Gewijzigd: van {old_label} naar {new_label}"}
+    old_period = _period_label(old)
+    new_period = _period_label(new)
+    if old_period != new_period:
+        return {"text": f"Periode gewijzigd op {new_label}", "old": old_period, "new": new_period}
     old_desc = old.get("description") or ""
     new_desc = new.get("description") or ""
     if not old_desc:

--- a/wies/core/form_mixins.py
+++ b/wies/core/form_mixins.py
@@ -58,6 +58,12 @@ class RvoFormMixin:
         "OrgPickerWidget": "rvo/widgets/org_picker.html",
     }
 
+    # Invisible widgets need no RVO template; skip the warning for them (#389).
+    widgets_without_rvo_template = {
+        "HiddenInput",
+        "MultipleHiddenInput",
+    }
+
     # Per-widget extra configuration applied whenever the widget class is
     # mapped to an RVO template. Each entry is merged onto the widget
     # instance. `DateInput` rendering — HTML5 <input type="date"> demands
@@ -87,6 +93,8 @@ class RvoFormMixin:
             field.widget.template_name = self.widget_templates[widget_class_name]
             for attr, value in self.widget_config.get(widget_class_name, {}).items():
                 setattr(field.widget, attr, value)
+        elif widget_class_name in self.widgets_without_rvo_template:
+            pass
         else:
             logger.warning(
                 "Widget '%s' for field '%s' not in RVO widget_templates mapping. Using default Django template.",

--- a/wies/core/inline_edit/base.py
+++ b/wies/core/inline_edit/base.py
@@ -41,6 +41,13 @@ class Editable:
     display: str | Callable[[Model], Any] | None = None
     save: Callable[[Model, Any], None] | None = None
 
+    # Extra context merged into the display partial on EVERY render path
+    # (initial panel render, inline-edit save, inline-edit cancel).
+    # Signature ``(obj, request) -> dict``. Use for values the partial needs
+    # but that aren't derivable from ``value`` alone — e.g. a navigation URL
+    # that must survive an edit/cancel round-trip (#395).
+    display_context: Callable[[Model, Any], dict] | None = None
+
     # For unbound editables (no 1:1 model field). `form_field_factory`
     # takes priority over field inference; `initial` reads the current value.
     form_field_factory: forms.Field | Callable[[], forms.Field] | None = None

--- a/wies/core/inline_edit/jinja.py
+++ b/wies/core/inline_edit/jinja.py
@@ -84,6 +84,9 @@ def inline_edit(ctx, obj, name, **extras):
         "hide_edit_button": getattr(spec, "hide_edit_button", False),
         "alert": None,
         "saved": False,
+        # display_context fires here and in _render_inline_edit_display, so the
+        # partial renders the same on first load and after an edit/cancel (#395).
+        **(spec.display_context(obj, request) if getattr(spec, "display_context", None) else {}),
         **extras,
     }
     # Trusted template; any user-supplied values go through Jinja's auto-escape.

--- a/wies/core/jinja2/parts/assignment_panel_content.html
+++ b/wies/core/jinja2/parts/assignment_panel_content.html
@@ -74,9 +74,7 @@
           {% endif %}
           <dt>Business Manager</dt>
           <dd>
-            {{ inline_edit(panel_data.assignment, "owner",
-                        owner_url=panel_data.owner_url,
-                        owner_mailto=panel_data.owner_mailto_href) }}
+            {{ inline_edit(panel_data.assignment, "owner") }}
           </dd>
           </c-data-list>
         </section>

--- a/wies/core/jinja2/parts/inline_edit/display.html
+++ b/wies/core/jinja2/parts/inline_edit/display.html
@@ -1,6 +1,5 @@
 {# Wrapper stays classless so HTMX swaps between display/form/collection
-  modes don't toggle layout classes on the target. The display layout
-  (clickable value row + optional pencil, flex row) lives on the inner block. #}
+  modes don't toggle layout classes on the target. #}
 <div id="{{ target }}">
   <div class="editable-field-display">
     {% if alert %}
@@ -9,8 +8,7 @@
         <p>{{ alert.message }}</p>
       </div>
     {% endif %}
-    <div class="editable-field-display__value"
-         {% if user_can_edit and not hide_edit_button %} hx-get="{{ edit_url }}?edit=true" hx-target="#{{ target }}" hx-swap="outerHTML" role="button" tabindex="0" style="cursor: pointer" {% endif %}>
+    <div class="editable-field-display__value">
       {% if display and display.template %}
         {% include display.template %}
       {% else %}
@@ -23,10 +21,10 @@
               hx-get="{{ edit_url }}?edit=true"
               hx-target="#{{ target }}"
               hx-swap="outerHTML"
+              data-tooltip="Bewerk {{ label|lower }}"
               aria-label="Bewerk {{ label }}">
         <span class="utrecht-icon rvo-icon rvo-icon-bewerken rvo-icon--md edit-icon-button__pencil"
-              role="img"
-              aria-label="Bewerk"></span>
+              aria-hidden="true"></span>
       </button>
     {% elif not user_can_edit and external_source %}
       <span class="source-lock"

--- a/wies/core/jinja2/rvo/forms/displays/assignment_owner.html
+++ b/wies/core/jinja2/rvo/forms/displays/assignment_owner.html
@@ -9,15 +9,25 @@
 #}
 {% if value %}
   <span class="inline-edit-owner">
-    {# Plain href like the organization links; an own hx-get broke history (#395). #}
+    {# This link sits inside the editable value wrapper, which sets
+      hx-swap="outerHTML" for its edit toggle. htmx inherits that, so without
+      an explicit innerHTML the swap would replace #side_panel-content itself
+      and break the panel. onclick stop prevents the wrapper's edit-mode
+      handler from also firing (#395). #}
     {% if owner_url %}
-      <a href="{{ owner_url }}" class="rvo-link">{{ value.name }}</a>
+      <a href="{{ owner_url }}"
+         hx-get="{{ owner_url }}"
+         hx-target="#side_panel-content"
+         hx-swap="innerHTML"
+         onclick="event.stopPropagation()"
+         class="rvo-link">{{ value.name }}</a>
     {% else %}
       {{ value.name }}
     {% endif %}
     {% if value.email %}
       <br>
       <a href="{{ owner_mailto or ('mailto:' ~ value.email) }}"
+         onclick="event.stopPropagation()"
          class="rvo-link">{{ value.email }}</a>
     {% endif %}
   </span>

--- a/wies/core/jinja2/rvo/forms/displays/assignment_owner.html
+++ b/wies/core/jinja2/rvo/forms/displays/assignment_owner.html
@@ -1,25 +1,11 @@
-{# Display for Assignment.owner. Context:
-  obj              — Assignment
-  value            — Colleague | None
-  owner_url        — optional: side-panel URL for navigating to the
-                     owner's profile. When absent, the name renders
-                     plain (post-save re-renders lose this extra).
-  owner_mailto     — optional: prefilled mailto URL. Falls back to
-                     a plain mailto:<email> when absent.
-#}
+{# owner_url / owner_mailto come from the owner editable's display_context,
+  so they survive an inline edit/cancel re-render (#395). #}
 {% if value %}
   <span class="inline-edit-owner">
-    {# This link sits inside the editable value wrapper, which sets
-      hx-swap="outerHTML" for its edit toggle. htmx inherits that, so without
-      an explicit innerHTML the swap would replace #side_panel-content itself
-      and break the panel. onclick stop prevents the wrapper's edit-mode
-      handler from also firing (#395). #}
     {% if owner_url %}
       <a href="{{ owner_url }}"
          hx-get="{{ owner_url }}"
          hx-target="#side_panel-content"
-         hx-swap="innerHTML"
-         onclick="event.stopPropagation()"
          class="rvo-link">{{ value.name }}</a>
     {% else %}
       {{ value.name }}
@@ -27,7 +13,6 @@
     {% if value.email %}
       <br>
       <a href="{{ owner_mailto or ('mailto:' ~ value.email) }}"
-         onclick="event.stopPropagation()"
          class="rvo-link">{{ value.email }}</a>
     {% endif %}
   </span>

--- a/wies/core/jinja2/rvo/forms/displays/assignment_owner.html
+++ b/wies/core/jinja2/rvo/forms/displays/assignment_owner.html
@@ -9,11 +9,9 @@
 #}
 {% if value %}
   <span class="inline-edit-owner">
+    {# Plain href like the organization links; an own hx-get broke history (#395). #}
     {% if owner_url %}
-      <a href="{{ owner_url }}"
-         hx-get="{{ owner_url }}"
-         hx-target="#side_panel-content"
-         class="rvo-link">{{ value.name }}</a>
+      <a href="{{ owner_url }}" class="rvo-link">{{ value.name }}</a>
     {% else %}
       {{ value.name }}
     {% endif %}

--- a/wies/core/jinja2/rvo/forms/displays/assignment_services.html
+++ b/wies/core/jinja2/rvo/forms/displays/assignment_services.html
@@ -18,7 +18,7 @@
       {% if row.colleague %}
         {% set pl = row.placement %}
         <div class="rvo-item-list__item rvo-item-list__item--filled{% if pl %} clickable-row{% endif %}"
-             {% if pl %}hx-get="/?plaatsing={{ pl.id }}" hx-target="#side_panel-container"{% endif %}>
+             {% if pl %}hx-get="/?plaatsing={{ pl.id }}" hx-target="#side_panel-content" hx-swap="innerHTML"{% endif %}>
           <div class="service-card__name">
             <div class="user-avatar">{{ row.colleague.name|first|upper }}</div>
             <span><strong>{{ row.colleague.name }}</strong> · {{ row.skill_name }}</span>

--- a/wies/core/tests/test_inline_edit.py
+++ b/wies/core/tests/test_inline_edit.py
@@ -643,6 +643,26 @@ class PlacementServiceEditablesTest(TestCase):
         self.service.refresh_from_db()
         assert self.service.description == "Dienst X"
 
+    def test_placement_period_edit_logs_event_on_assignment(self):
+        """A period edit on a placement (the profile path) is mirrored as a
+        Team event on the parent assignment timeline (#393)."""
+        url = reverse("inline-edit", args=["placement", self.placement.id, "period"])
+        resp = self.client.post(
+            url,
+            {
+                "period_source": Placement.PLACEMENT,
+                "specific_start_date": "2026-06-19",
+                "specific_end_date": "2026-12-31",
+            },
+        )
+        assert resp.status_code == 200
+        assignment = self.service.assignment
+        events = list(Event.objects.filter(object_type="Assignment", object_id=assignment.id, action="update"))
+        assert len(events) == 1
+        change = events[0].context["changes"][0]
+        assert change["new"]["end_date"] == "2026-12-31"
+        assert change["new"]["has_custom_period"] is False
+
 
 class AssignmentServicesDisplayTest(TestCase):
     """Regression tests for the services collection display partial —
@@ -988,7 +1008,7 @@ class ServicesRenderChangeUnitTests(TestCase):
             "new": self._row(1, "Python", "Jan", description="nieuw"),
         }
         assert _services_render_change(change) == {
-            "text": "Toelichting gewijzigd op Python (Jan)",
+            "text": "Toelichting gewijzigd voor Python (Jan)",
             "old": "oud",
             "new": "nieuw",
         }
@@ -999,7 +1019,7 @@ class ServicesRenderChangeUnitTests(TestCase):
             "new": self._row(1, "Python", "Jan", description="nieuw"),
         }
         assert _services_render_change(change) == {
-            "text": "Toelichting toegevoegd op Python (Jan)",
+            "text": "Toelichting toegevoegd voor Python (Jan)",
             "new": "nieuw",
         }
 
@@ -1009,22 +1029,25 @@ class ServicesRenderChangeUnitTests(TestCase):
             "new": self._row(1, "Python", "Jan", description=""),
         }
         assert _services_render_change(change) == {
-            "text": "Toelichting verwijderd op Python (Jan)",
+            "text": "Toelichting verwijderd voor Python (Jan)",
             "old": "oud",
         }
 
     def test_period_custom_set(self):
-        # Switching from "follows assignment" to a custom period (#393).
+        # Switching from inherited to a custom period (#393).
         # `has_custom_period` is inverted: True == inherits, False == own.
+        # Inherited still shows the dates so the old period stays visible.
         change = {
-            "old": self._row(1, "Python", "Jan", has_custom_period=True),
+            "old": self._row(
+                1, "Python", "Jan", has_custom_period=True, start_date="2026-01-01", end_date="2026-06-30"
+            ),
             "new": self._row(
                 1, "Python", "Jan", has_custom_period=False, start_date="2026-01-01", end_date="2026-06-30"
             ),
         }
         assert _services_render_change(change) == {
-            "text": "Periode gewijzigd op Python (Jan)",
-            "old": "volgt opdracht",
+            "text": "Periode gewijzigd van Python (Jan)",
+            "old": "01-01-2026 t/m 30-06-2026 (volgt opdracht)",
             "new": "01-01-2026 t/m 30-06-2026",
         }
 
@@ -1038,7 +1061,7 @@ class ServicesRenderChangeUnitTests(TestCase):
             ),
         }
         assert _services_render_change(change) == {
-            "text": "Periode gewijzigd op Python (Jan)",
+            "text": "Periode gewijzigd van Python (Jan)",
             "old": "01-01-2026 t/m 30-06-2026",
             "new": "01-02-2026 t/m 30-06-2026",
         }

--- a/wies/core/tests/test_inline_edit.py
+++ b/wies/core/tests/test_inline_edit.py
@@ -838,6 +838,32 @@ class AssignmentServicesAuditTest(TestCase):
         assert resp.status_code == 200
         assert not Event.objects.filter(object_type="Assignment", object_id=self.assignment.id).exists()
 
+    def test_services_post_emits_event_on_period_change(self):
+        """A period-only edit still emits a team audit event (#393)."""
+        data = {
+            "service-TOTAL_FORMS": "2",
+            **self.FORMSET_MGMT_KEYS,
+            # Filled row: drop the inherit checkbox and give a custom period.
+            "service-0-id": str(self.filled_service.id),
+            "service-0-skill": str(self.skill_python.id),
+            "service-0-description": "Filled",
+            "service-0-is_filled": "ingevuld",
+            "service-0-colleague": str(self.colleague.id),
+            "service-0-placement_id": str(self.placement.id),
+            "service-0-placement_start_date": "2026-01-01",
+            "service-0-placement_end_date": "2026-06-30",
+            **self._row(1, service=self.vacant_service, skill=self.skill_java, description="Vacant"),
+        }
+        resp = self.client.post(self.url, data)
+        assert resp.status_code == 200
+        self.placement.refresh_from_db()
+        assert self.placement.specific_start_date is not None
+        events = list(Event.objects.filter(object_type="Assignment", object_id=self.assignment.id, action="update"))
+        assert len(events) == 1
+        changes = events[0].context["changes"]
+        assert len(changes) == 1
+        assert changes[0]["old"]["id"] == self.filled_service.id
+
     def test_switch_filled_to_aanvraag_removes_placement(self):
         """Flipping a filled service to "aanvraag" must free the placement,
         even when the (hidden) consultant select still posts its value —
@@ -929,8 +955,14 @@ class ServicesRenderChangeUnitTests(TestCase):
     branch (added / removed / skill changed / colleague filled /
     description add/remove/change)."""
 
-    def _row(self, sid, skill_name, colleague_name=None, description=""):
-        return {"id": sid, "skill_name": skill_name, "colleague_name": colleague_name, "description": description}
+    def _row(self, sid, skill_name, colleague_name=None, description="", **period):
+        return {
+            "id": sid,
+            "skill_name": skill_name,
+            "colleague_name": colleague_name,
+            "description": description,
+            **period,
+        }
 
     def test_added(self):
         change = {"old": None, "new": self._row(2, "Java", None)}
@@ -979,6 +1011,36 @@ class ServicesRenderChangeUnitTests(TestCase):
         assert _services_render_change(change) == {
             "text": "Toelichting verwijderd op Python (Jan)",
             "old": "oud",
+        }
+
+    def test_period_custom_set(self):
+        # Switching from "follows assignment" to a custom period (#393).
+        # `has_custom_period` is inverted: True == inherits, False == own.
+        change = {
+            "old": self._row(1, "Python", "Jan", has_custom_period=True),
+            "new": self._row(
+                1, "Python", "Jan", has_custom_period=False, start_date="2026-01-01", end_date="2026-06-30"
+            ),
+        }
+        assert _services_render_change(change) == {
+            "text": "Periode gewijzigd op Python (Jan)",
+            "old": "volgt opdracht",
+            "new": "01-01-2026 t/m 30-06-2026",
+        }
+
+    def test_period_dates_changed(self):
+        change = {
+            "old": self._row(
+                1, "Python", "Jan", has_custom_period=False, start_date="2026-01-01", end_date="2026-06-30"
+            ),
+            "new": self._row(
+                1, "Python", "Jan", has_custom_period=False, start_date="2026-02-01", end_date="2026-06-30"
+            ),
+        }
+        assert _services_render_change(change) == {
+            "text": "Periode gewijzigd op Python (Jan)",
+            "old": "01-01-2026 t/m 30-06-2026",
+            "new": "01-02-2026 t/m 30-06-2026",
         }
 
 

--- a/wies/core/tests/test_inline_edit.py
+++ b/wies/core/tests/test_inline_edit.py
@@ -140,6 +140,21 @@ class InlineEditInfrastructureTest(TestCase):
         self.assertContains(resp, "editable-field-display")
         self.assertContains(resp, "rvo-icon-bewerken")
 
+    def test_only_pencil_enters_edit_mode(self):
+        """The value itself is not clickable — only the pencil button opens
+        edit mode — so interactive content inside it (links, "Toon meer")
+        doesn't bubble into edit mode (#395)."""
+        resp = self.client.get(self.url)
+        content = resp.content.decode()
+        value_div = content.split('class="editable-field-display__value"')[1].split(">")[0]
+        assert "hx-get" not in value_div
+        assert 'role="button"' not in value_div
+        # The pencil button still carries the edit trigger.
+        assert "edit=true" in content
+        assert "edit-icon-button" in content
+        # And a tooltip aiding discoverability now the value isn't clickable.
+        assert 'data-tooltip="Bewerk ' in content
+
     def test_get_edit_returns_form(self):
         resp = self.client.get(self.url + "?edit=true")
         assert resp.status_code == 200
@@ -548,6 +563,25 @@ class AssignmentEditablesFullTest(TestCase):
         # Email link is rendered by the custom display partial.
         self.assertContains(resp, f"mailto:{self.colleague.email}")
 
+    def test_owner_link_present_on_display(self):
+        # The navigation link to the owner's profile is supplied by the
+        # editable's display_context, not a panel-only extra (#395).
+        resp = self.client.get(self._url("owner"))
+        self.assertContains(resp, f"collega={self.colleague.id}")
+
+    def test_owner_link_survives_cancel(self):
+        # Edit + cancel must re-render the link, not drop it to plain text (#395).
+        resp = self.client.get(self._url("owner") + "?cancel=true")
+        assert resp.status_code == 200
+        self.assertContains(resp, f"collega={self.colleague.id}")
+        self.assertContains(resp, f"mailto:{self.colleague.email}")
+
+    def test_owner_link_survives_save(self):
+        # A successful save re-renders the display; the link must persist (#395).
+        resp = self.client.post(self._url("owner"), {"owner": self.colleague.id})
+        assert resp.status_code == 200
+        self.assertContains(resp, f"collega={self.colleague.id}")
+
 
 class AssignmentCreateFormIntegrationTest(TestCase):
     """Verify that AssignmentCreateForm composes its fields from the
@@ -708,7 +742,12 @@ class AssignmentServicesDisplayTest(TestCase):
     def test_filled_row_is_clickable_to_placement_panel(self):
         resp = self.client.get(self.url + "?cancel=true")
         assert resp.status_code == 200
-        self.assertContains(resp, 'hx-target="#side_panel-container"')
+        # Renders inside an open panel, so it must swap the inner content;
+        # targeting #side_panel-container rebuilds the dialog and htmx falls
+        # back to a full page load.
+        self.assertContains(resp, 'hx-target="#side_panel-content"')
+        self.assertNotContains(resp, 'hx-target="#side_panel-container"')
+        self.assertContains(resp, "plaatsing=")
         self.assertContains(resp, self.colleague.name)
         self.assertContains(resp, "rvo-item-list__item--filled")
         self.assertContains(resp, "clickable-row")

--- a/wies/core/views.py
+++ b/wies/core/views.py
@@ -1,5 +1,4 @@
 import logging
-import urllib.parse
 from collections import Counter
 from datetime import date, timedelta
 
@@ -222,23 +221,6 @@ def _build_assignment_panel_data(assignment, request):
 
     team_members = vacancy_list + list(current_grouped.values()) + list(historical_grouped.values())
 
-    owner_mailto_href = ""
-    if assignment.owner and assignment.owner.email:
-        opdracht_url = request.build_absolute_uri(reverse("assignment-list") + f"?opdracht={assignment.id}")
-        subject = urllib.parse.quote(f"Informatieverzoek over opdracht {assignment.name}")
-        body_lines = [
-            f"Beste {assignment.owner.name},",
-            "",
-            f"Ik zag deze opdracht {opdracht_url} op WIES."
-            + (f" De beschrijving is: {assignment.extra_info}" if assignment.extra_info else ""),
-            "",
-            "Kun je me hier meer informatie over geven?",
-        ]
-        consultant_name = getattr(getattr(request.user, "colleague", None), "name", "")
-        body_lines += ["", "Met vriendelijke groet,", "", consultant_name]
-        body = urllib.parse.quote("\n".join(body_lines))
-        owner_mailto_href = f"mailto:{assignment.owner.email}?subject={subject}&body={body}"
-
     return {
         "panel_content_template": "parts/assignment_panel_content.html",
         "panel_title": assignment.name,
@@ -247,8 +229,6 @@ def _build_assignment_panel_data(assignment, request):
         "team_members": team_members,
         "user_can_edit": has_permission(Verb.UPDATE, assignment, request.user),
         "show_updates_tab": assignment.source != "otys_iir",
-        "owner_url": _build_panel_url(request, collega=assignment.owner.id) if assignment.owner else "",
-        "owner_mailto_href": owner_mailto_href,
         "organization_count": assignment.organization_relations.count(),
     }
 
@@ -2599,6 +2579,10 @@ def _render_inline_edit_display(
             value = _current_value(obj, spec)
         else:
             value = {e.field or e.name: _current_value(obj, e) for e in editables}
+    extra = {}
+    display_context = getattr(spec, "display_context", None)
+    if alert is None and display_context is not None:
+        extra = display_context(obj, request)
     ctx = {
         **_inline_edit_base_ctx(editable_set, spec, obj),
         "value": value,
@@ -2608,6 +2592,7 @@ def _render_inline_edit_display(
         ),
         "hide_edit_button": getattr(spec, "hide_edit_button", False),
         "alert": alert,
+        **extra,
     }
     response = render(request, "parts/inline_edit/display.html", ctx)
     if saved:

--- a/wies/core/views.py
+++ b/wies/core/views.py
@@ -2736,6 +2736,29 @@ def _diff_collection_state(old_state: list[dict], new_state: list[dict]) -> list
     return changes
 
 
+def _emit_placement_change_on_assignment(placement, before_row: dict, user) -> None:
+    """Record a placement edit as a "Team" event on its parent assignment,
+    so it renders identically to the Team-bewerken flow (#393)."""
+    from wies.core.editables.assignment import placement_audit_row  # noqa: PLC0415 — avoids circular import
+
+    assignment = placement.service.assignment
+    after_row = placement_audit_row(placement)
+    if before_row == after_row:
+        return
+    create_event(
+        object_type="Assignment",
+        action="update",
+        source="user",
+        object_id=assignment.id,
+        user=user,
+        context={
+            "field_name": "services",
+            "field_label": "Team",
+            "changes": [{"old": before_row, "new": after_row}],
+        },
+    )
+
+
 def inline_edit_view(request, model_label, pk, name):
     """Generic HTMX endpoint. See ``features/inline-editing.md`` for the full contract."""
     editable_set = REGISTRY.get(model_label)
@@ -2783,6 +2806,14 @@ def inline_edit_view(request, model_label, pk, name):
                 before = {e.name: _current_value(obj, e) for e in editables}
             else:
                 before = _current_value(obj, spec)
+            # A placement edit (e.g. period via the profile) has no audit
+            # type of its own; mirror it onto the parent assignment's
+            # timeline like the "Team bewerken" flow (#393).
+            placement_before = None
+            if type(obj).__name__ == "Placement":
+                from wies.core.editables.assignment import placement_audit_row  # noqa: PLC0415 — avoids circular import
+
+                placement_before = placement_audit_row(obj)
             with transaction.atomic():
                 save_spec(spec, editables, form.cleaned_data, obj)
                 if isinstance(spec, EditableGroup):
@@ -2797,6 +2828,9 @@ def inline_edit_view(request, model_label, pk, name):
                     request.user,
                     child_editables=editables if isinstance(spec, EditableGroup) else None,
                 )
+                if placement_before is not None:
+                    obj.refresh_from_db()
+                    _emit_placement_change_on_assignment(obj, placement_before, request.user)
             return _render_inline_edit_display(
                 request,
                 editable_set,


### PR DESCRIPTION
Fixes three bugs on the opdracht side panel.

## Solves
- Solves #395 
- Solves #393 
- Solves #389 

## Changes

### #395 — Business Manager link broke the page
The owner display rendered the link with its own `hx-get` + `hx-target="#side_panel-content"`. That swapped a partial into the panel out of band, leaving the page without scroll and with a dead back button. The working organization links in the same panel use a plain `href` and let the side-panel bridge handle navigation — the owner link now does the same (plain `href`, no `hx-get`).

### #393 — period change not logged as an update
`_services_audit_state()` only captured skill / colleague / description, so editing **only** a placement's period produced identical before/after states and no audit event. The period (`has_custom_period` + start/end date) is now part of the audit state, and `_services_render_change()` renders a "Periode gewijzigd op …" timeline entry with from/to dates.

### #389 — HiddenInput widget warning
`RvoFormMixin` logged a warning for every widget without an RVO template, including `HiddenInput` (e.g. the hidden `id` / `placement_id` fields). Hidden inputs need no styling, so they're now listed in `widgets_without_rvo_template` and fall back to the Django default silently.

## Testing
- `just test` — 521 Python tests + 31 JS tests pass
- Added unit tests for the period-change render branch and an integration test asserting a period-only team edit emits an event
- Manually verified all three in the running app (BM link navigates correctly; period change appears in Updates; no more HiddenInput warning in the logs)