### PR TITLE
fix removing teammember from team

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
+- 413: fix that teammembers on assignment can be removed
 - 372: the BM-owner (and support staff in `STAFF_EMAILS`) can delete wies-sourced opdrachten, with a confirmation modal and an audit-trail event; both create and delete now snapshot the rollen (with who filled them) and the opdrachtgevers
 
 ## 2026-01-16

--- a/wies/core/forms.py
+++ b/wies/core/forms.py
@@ -238,6 +238,19 @@ class ServiceForm(RvoFormMixin, forms.Form):
         cleaned_data = super().clean()
         skill_val = cleaned_data.get("skill", "")
         new_skill_name = cleaned_data.get("new_skill_name", "").strip()
+        # A row the user removed in the UI ("Verwijderen") leaves a gap
+        # in the formset indexes that Django re-materialises as a blank
+        # form. Treat any row with no identifying content as deleted and
+        # skip validation — extract_services_data drops it before save.
+        is_empty_row = (
+            not cleaned_data.get("id")
+            and not skill_val
+            and not new_skill_name
+            and not cleaned_data.get("description")
+            and not cleaned_data.get("colleague")
+        )
+        if is_empty_row:
+            return cleaned_data
         if skill_val == "__new__" and not new_skill_name:
             self.add_error("new_skill_name", "Voer een naam in voor de nieuwe rol.")
         has_skill = (skill_val and skill_val != "__new__") or new_skill_name

--- a/wies/core/tests/test_inline_edit.py
+++ b/wies/core/tests/test_inline_edit.py
@@ -1008,6 +1008,38 @@ class AssignmentServicesAuditTest(TestCase):
         assert changes[0]["old"]["description"] == "Filled"
         assert changes[0]["new"]["description"] == "New description"
 
+    def test_remove_row_via_team_bewerken_deletes_service(self):
+        """Bug: in "Team bewerken", clicking "Verwijderen" on a row and
+        then "Opslaan" must delete that row's service. The JS removes
+        the row from the DOM without renumbering or decrementing
+        ``TOTAL_FORMS``, so the server sees a gap in the form indexes.
+        Django's formset interprets the gap as an empty form, and
+        ``ServiceForm.clean()`` rejects it with "Vul een periode in...".
+        The save fails, the deleted row re-renders as a blank
+        errored form, and the user can never delete a team member."""
+        original_vacant_id = self.vacant_service.id
+        # Only submit row 0 (the filled service), simulating the user
+        # having clicked "Verwijderen" on row 1 (the vacant one).
+        # TOTAL_FORMS is unchanged — this is the production behaviour.
+        data = {
+            "service-TOTAL_FORMS": "2",
+            **self.FORMSET_MGMT_KEYS,
+            **self._row(
+                0,
+                service=self.filled_service,
+                skill=self.skill_python,
+                description="Filled",
+                is_filled=True,
+                colleague=self.colleague,
+            ),
+        }
+        resp = self.client.post(self.url, data)
+        assert resp.status_code == 200
+        # The removed service must actually be gone from the DB.
+        assert not Service.objects.filter(id=original_vacant_id).exists()
+        # And the surviving service is unchanged.
+        assert Service.objects.filter(id=self.filled_service.id).exists()
+
 
 class AssignmentServicesEditFormPeriodTest(TestCase):
     """Regression: opening the team editor must reflect each row's


### PR DESCRIPTION
closes #412  (hierin staat de bug beschrijving vanuit de UI)

oorzaak is dat django in een apart veld bijhoudt hoeveel velden er zijn. bij delete vanuit js wordt dit getal niet aangepast, waardoor er een nieuwe lege regel wordt geinjecteerd. dit geval bijhouden is best tricky, dus daarom is ervoor gekozen voor backend logica te gaan, waarbij elke compleet lege regel geskipt wordt.