### PR TITLE
remove separate modelauthbackend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
-- ?: remove `ModelBackend` from `AUTHENTICATION_BACKENDS`; `AuthBackend` now inherits from `ModelBackend` so group permissions keep resolving via a single backend, but there is no second password-login path)
+- 417: remove `ModelBackend` from `AUTHENTICATION_BACKENDS`; `AuthBackend` now inherits from `ModelBackend` so group permissions keep resolving via a single backend, but there is no second password-login path)
 
 ## 2026-06-24
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
-- ?: ...
+- ?: remove `ModelBackend` from `AUTHENTICATION_BACKENDS`; `AuthBackend` now inherits from `ModelBackend` so group permissions keep resolving via a single backend, but there is no second password-login path)
 
 ## 2026-06-24
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -133,7 +133,6 @@ LOGIN_URL = "login"
 
 AUTHENTICATION_BACKENDS = [
     "wies.rijksauth.auth_backend.AuthBackend",
-    "django.contrib.auth.backends.ModelBackend",
 ]
 
 AUTH_USER_MODEL = "rijksauth.User"

--- a/wies/core/tests/test_permissions.py
+++ b/wies/core/tests/test_permissions.py
@@ -52,8 +52,8 @@ class HasPermissionEngineTest(_Setup):
 
     def test_superuser_gets_all_perms_via_django_model_backend(self):
         # The engine no longer short-circuits superusers; they pass because
-        # rules consult user.has_perm(...) and Django's ModelBackend grants
-        # superusers every permission.
+        # rules consult user.has_perm(...) and AuthBackend (inheriting from
+        # ModelBackend) grants superusers every permission.
         assert has_permission(Verb.UPDATE, self.assignment, self.superuser) is True
         assert has_permission(Verb.UPDATE, self.placement, self.superuser) is True
         assert has_permission(Verb.UPDATE, self.assignment, self.superuser, AssignmentEditables.extra_info) is True

--- a/wies/rijksauth/auth_backend.py
+++ b/wies/rijksauth/auth_backend.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.backends import BaseBackend
+from django.contrib.auth.backends import ModelBackend
 
 from .services.events import create_auth_event
 
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 
-class AuthBackend(BaseBackend):
+class AuthBackend(ModelBackend):
     def authenticate(self, request, username=None, email=None, **kwargs):
         if not username:
             msg = "username is required"

--- a/wies/rijksauth/middleware.py
+++ b/wies/rijksauth/middleware.py
@@ -23,6 +23,6 @@ class AutoLoginMiddleware:
             if not user:
                 user = User.objects.first()
             if user:
-                login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+                login(request, user, backend="wies.rijksauth.auth_backend.AuthBackend")
                 logger.info("Auto-login: logged in as %s", user)
         return self.get_response(request)


### PR DESCRIPTION
closes #418 

`ModelBackend` accepteert username/password tegen Django's user-tabel.
Dat is een tweede authenticatie-pad dat OIDC omzeilt, wat onwenselijk is. Het naïef verwijderen van `ModelBackend` breekt
echter:

1. **Beheerder/BDM permissies**: `permissions.py:40` en `views.py:1219`
   gebruiken `user.has_perm(...)` voor group-based permissies. Onze
   `AuthBackend` erft van `BaseBackend` en implementeert `has_perm()`
   niet — dat delegeert dus stilletjes naar `ModelBackend`'s
   permission-resolver. Test [test_permissions.py:53-58](wies/core/tests/test_permissions.py#L53-L58)
   documenteert dit zelfs expliciet.
2. **Superuser-toegang**: `is_superuser=True` levert nu "alle
   permissies" via `ModelBackend.has_perm`. Zonder backend krijgt een
   superuser geen permissies meer.
3. **Local dev `SKIP_OIDC`**: [middleware.py:26](wies/rijksauth/middleware.py#L26)
   roept `login(request, user, backend="django.contrib.auth.backends.ModelBackend")`
   expliciet aan.

De oplossing is om `AuthBackend` te laten erven van `ModelBackend` in
plaats van `BaseBackend`. We hergebruiken dan de permission-resolver
(group/user permissions + superuser short-circuit) maar overschrijven
`authenticate()` zó dat alleen email-based authenticatie via OIDC
werkt — geen wachtwoord-pad meer. Het tweede backend kan dan weg.