### PR TITLE
improve text search: commit search field on blur

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
-- 437: the search field now commits on blur — trimming or clearing the text and clicking away updates the URL/results, without needing Enter or the magnifier
+- 446: the search field now commits on blur — trimming or clearing the text and clicking away updates the URL/results, without needing Enter or the magnifier
 
 ## 2026-07-08
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
-- ?:
+- 437: the search field now commits on blur — trimming or clearing the text and clicking away updates the URL/results, without needing Enter or the magnifier
 
 ## 2026-07-08
 

--- a/wies/core/static/js/filters/filters.js
+++ b/wies/core/static/js/filters/filters.js
@@ -457,11 +457,9 @@ document.addEventListener("DOMContentLoaded", function () {
     commitSearch();
   });
 
-  // Clicking out of the field (blur) commits the current text when it differs
-  // from the active search term — so trimming or clearing the field and clicking
-  // away keeps the URL/results in sync, without requiring Enter or the magnifier.
-  // (commitSearch() itself blurs the input; the value-equality check makes that
-  // re-entrant blur a no-op.)
+  // Commit on blur so clearing/trimming the field and clicking away syncs the
+  // results. The equality check skips unchanged blurs, including commitSearch()'s
+  // own internal blur() (which would otherwise re-enter here).
   document.body.addEventListener(
     "blur",
     function (e) {

--- a/wies/core/static/js/filters/filters.js
+++ b/wies/core/static/js/filters/filters.js
@@ -457,6 +457,24 @@ document.addEventListener("DOMContentLoaded", function () {
     commitSearch();
   });
 
+  // Clicking out of the field (blur) commits the current text when it differs
+  // from the active search term — so trimming or clearing the field and clicking
+  // away keeps the URL/results in sync, without requiring Enter or the magnifier.
+  // (commitSearch() itself blurs the input; the value-equality check makes that
+  // re-entrant blur a no-op.)
+  document.body.addEventListener(
+    "blur",
+    function (e) {
+      var input = e.target;
+      if (!input || input.id !== "search") return;
+      var hiddenSearch = document.getElementById("search-filter-value");
+      var active = hiddenSearch ? hiddenSearch.value : "";
+      if (input.value.trim() === active) return;
+      commitSearch();
+    },
+    true, // capture: blur does not bubble
+  );
+
   // Click the magnifier icon → run the search (same as Enter). Only acts on the
   // global #search field's wrapper; per-group searches handle their own input.
   document.body.addEventListener("click", function (e) {


### PR DESCRIPTION
closes #437

The search field committed only on Enter or the magnifier icon. Now blurring the field (clicking away) commits the current text when it differs from the active search term — so trimming or clearing the text and clicking away keeps the URL/results in sync, without needing Enter.

- No commit fires when the (trimmed) field value equals the active term, avoiding a redundant request on every click-out.
- The value-equality check also makes `commitSearch()`'s own internal `input.blur()` a no-op (no double-fire).