### PR TITLE
rules: add comment style guidance

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -7,6 +7,15 @@
 - Format with `ruff format`, lint with `ruff check --fix`
 - When adding `# noqa` comments, always include what the rule enforces and why the suppression is justified here (e.g. `# noqa: F401 (unused import), PLC0415 (import not at top level) — Django signal registration must happen inside ready()`)
 
+## Comments
+
+Follow the [Google style guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) principle (applies to all languages here, not just Python): comment the non-obvious, not the code that already reads for itself.
+
+- Explain *why*, or what is surprising — not *what* a line plainly does.
+- Skip comments that restate the code (`// commit on blur` above a blur listener adds nothing).
+- Keep the ones that save a reader from a wrong assumption: re-entrancy, ordering constraints, workarounds, why a guard exists, why a non-obvious approach was chosen.
+- Prefer one tight comment over a multi-line block. A block that keeps growing is usually a hint the code wants a clearer name or a small refactor.
+
 ## Django
 
 - Models in `wies/core/models.py`

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -11,7 +11,7 @@
 
 Follow the [Google style guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) principle (applies to all languages here, not just Python): comment the non-obvious, not the code that already reads for itself.
 
-- Explain *why*, or what is surprising — not *what* a line plainly does.
+- Explain _why_, or what is surprising — not _what_ a line plainly does.
 - Skip comments that restate the code (`// commit on blur` above a blur listener adds nothing).
 - Keep the ones that save a reader from a wrong assumption: re-entrancy, ordering constraints, workarounds, why a guard exists, why a non-obvious approach was chosen.
 - Prefer one tight comment over a multi-line block. A block that keeps growing is usually a hint the code wants a clearer name or a small refactor.


### PR DESCRIPTION
Adds a `## Comments` section to `.claude/rules/code-style.md` codifying the [Google style guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) principle: comment the non-obvious, not what the code already says.

Applies to all languages in the repo (Python, JS, templates). Motivated by a preference to keep comment blocks tight — explain *why* / the surprising bits (re-entrancy, ordering, workarounds), skip line-by-line narration.

No product code changes; `.claude` config only, so no CHANGES.md entry.