### PR TITLE
Hide private placements from the opdracht audit timeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ This files lists the changes during the lifetime of this project.
 ## unreleased
 
 - ?: x
+- ?: fix the opdracht Updates tab revealing colleague names of planned or ended placements, which the Team tab hides from everyone except the placed colleague and the BM-owner
 
 ## 2026-07-15
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ This files lists the changes during the lifetime of this project.
 ## unreleased
 
 - ?: x
-- ?: fix the opdracht Updates tab revealing colleague names of planned or ended placements, which the Team tab hides from everyone except the placed colleague and the BM-owner
+- 468: fix the opdracht Updates tab revealing colleague names of planned or ended placements, which the Team tab hides from everyone except the placed colleague and the BM-owner
 
 ## 2026-07-15
 

--- a/wies/core/editables/assignment.py
+++ b/wies/core/editables/assignment.py
@@ -281,6 +281,26 @@ def _change_colleague_names(change: dict) -> set[str]:
     return names
 
 
+def _visible_colleague_names(assignment, request, viewer) -> set[str]:
+    """Names ``viewer`` may already see on this opdracht.
+
+    Cached on the request, keyed by opdracht: the timeline calls this once per
+    team event and ``visible_service_rows`` costs a query each time. Keyed on
+    the request rather than the assignment instance because the answer depends
+    on the viewer, and a request has exactly one.
+    """
+    cache = getattr(request, "wies_visible_colleague_names", None)
+    if cache is None:
+        cache = {}
+        request.wies_visible_colleague_names = cache
+    if assignment.id not in cache:
+        names = {row["colleague"].name for row in visible_service_rows(assignment, request) if row["colleague"]}
+        if viewer is not None:
+            names.add(viewer.name)
+        cache[assignment.id] = names
+    return cache[assignment.id]
+
+
 def _services_visible_changes(assignment, request, changes: list[dict]) -> list[dict]:
     """Viewer-filtered team changes for the audit timeline, mirroring
     ``visible_service_rows``: a name the team list hides must not resurface
@@ -295,9 +315,7 @@ def _services_visible_changes(assignment, request, changes: list[dict]) -> list[
     viewer = getattr(getattr(request, "user", None), "colleague", None)
     if viewer is not None and assignment.owner_id == viewer.id:
         return changes
-    allowed = {row["colleague"].name for row in visible_service_rows(assignment, request) if row["colleague"]}
-    if viewer is not None:
-        allowed.add(viewer.name)
+    allowed = _visible_colleague_names(assignment, request, viewer)
     return [change for change in changes if _change_colleague_names(change) <= allowed]
 
 

--- a/wies/core/editables/assignment.py
+++ b/wies/core/editables/assignment.py
@@ -272,6 +272,35 @@ def _date_nl(iso: str | None) -> str | None:
     return f"{d}-{m}-{y}"
 
 
+def _change_colleague_names(change: dict) -> set[str]:
+    names = set()
+    for side in ("old", "new"):
+        row = change.get(side)
+        if row and row.get("colleague_name"):
+            names.add(row["colleague_name"])
+    return names
+
+
+def _services_visible_changes(assignment, request, changes: list[dict]) -> list[dict]:
+    """Viewer-filtered team changes for the audit timeline, mirroring
+    ``visible_service_rows``: a name the team list hides must not resurface
+    here. Keyed on the colleague *name* in the snapshot, not the row id: the
+    snapshot is frozen, so a row whose placement was since removed or re-filled
+    would otherwise leak the earlier name.
+
+    A change survives only if every name it mentions is one the viewer may
+    already see on this opdracht. Vacancies name nobody and always survive.
+    Dropped whole rather than redacted, so the timeline cannot betray that a
+    hidden placement exists (same reason ``team_count`` is filtered)."""
+    viewer = getattr(getattr(request, "user", None), "colleague", None)
+    if viewer is not None and assignment.owner_id == viewer.id:
+        return changes
+    allowed = {row["colleague"].name for row in visible_service_rows(assignment, request) if row["colleague"]}
+    if viewer is not None:
+        allowed.add(viewer.name)
+    return [change for change in changes if _change_colleague_names(change) <= allowed]
+
+
 def _services_render_change(change: dict) -> dict:
     old, new = change.get("old"), change.get("new")
     if old is None:
@@ -367,6 +396,7 @@ class AssignmentEditables(EditableSet):
         save=_save_services,
         audit_state=_services_audit_state,
         render_change=_services_render_change,
+        visible_changes=_services_visible_changes,
         hide_edit_button=True,
         form_template="parts/assignment_services_form.html",
         display="rvo/forms/displays/assignment_services.html",

--- a/wies/core/editables/assignment.py
+++ b/wies/core/editables/assignment.py
@@ -289,10 +289,9 @@ def _visible_colleague_names(assignment, request, viewer) -> set[str]:
     the request rather than the assignment instance because the answer depends
     on the viewer, and a request has exactly one.
     """
-    cache = getattr(request, "wies_visible_colleague_names", None)
-    if cache is None:
-        cache = {}
-        request.wies_visible_colleague_names = cache
+    if not hasattr(request, "wies_visible_colleague_names"):
+        request.wies_visible_colleague_names = {}
+    cache = request.wies_visible_colleague_names
     if assignment.id not in cache:
         names = {row["colleague"].name for row in visible_service_rows(assignment, request) if row["colleague"]}
         if viewer is not None:

--- a/wies/core/inline_edit/base.py
+++ b/wies/core/inline_edit/base.py
@@ -132,6 +132,12 @@ class EditableCollection:
     # bullet line in the audit log UI, optionally with an inline
     # Van/Naar block under the bullet for long values.
     render_change: Callable[[dict], dict] | None = None
+    # Drop changes the viewer may not see, before ``render_change`` runs.
+    # ``audit_state`` snapshots every row regardless of viewer, so a
+    # collection whose display is viewer-filtered MUST filter here too or
+    # the audit log becomes a second, unguarded read path onto the same
+    # rows. Signature ``(obj, request, changes) -> changes``.
+    visible_changes: Callable[[Model, Any, list[dict]], list[dict]] | None = None
     # Suppress the auto-rendered pencil + clickable-value wrapper on the
     # display partial. Use when the parent template provides its own
     # edit trigger (e.g. the "Team bewerken" button).

--- a/wies/core/tests/test_assignment_views.py
+++ b/wies/core/tests/test_assignment_views.py
@@ -1,3 +1,4 @@
+import datetime
 import importlib
 
 from django.apps import apps
@@ -5,6 +6,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 
 from wies.core.models import (
     Assignment,
@@ -778,6 +780,138 @@ class AssignmentEditAttributeTest(TestCase):
         assert response.status_code == 200
         self.assertContains(response, 'id="tab-updates"')
         self.assertContains(response, 'id="tab-panel-updates"')
+
+
+class TimelinePlacementPrivacyTests(TestCase):
+    """The updates tab must honour the placement-visibility rule the team tab
+    applies: a planned or ended placement is private to the placed colleague
+    and the BM-owner, so its colleague name must not surface in a Team event."""
+
+    def setUp(self):
+        self.client = Client()
+        self.owner_user = User.objects.create_user(email="owner@rijksoverheid.nl", first_name="O", last_name="wner")
+        self.hidden_user = User.objects.create_user(email="hidden@rijksoverheid.nl", first_name="H", last_name="idden")
+        self.unrelated_user = User.objects.create_user(email="other@rijksoverheid.nl", first_name="U", last_name="n")
+
+        self.owner_colleague = Colleague.objects.create(
+            user=self.owner_user, name="Owner Colleague", email="owner@rijksoverheid.nl", source="wies"
+        )
+        self.hidden_colleague = Colleague.objects.create(
+            user=self.hidden_user, name="Hidden Colleague", email="hidden@rijksoverheid.nl", source="wies"
+        )
+
+        self.assignment = Assignment.objects.create(name="DTC4NL", owner=self.owner_colleague, source="wies")
+        skill = Skill.objects.create(name="Software Engineer")
+        self.service = Service.objects.create(description="", assignment=self.assignment, skill=skill, source="wies")
+
+        # Not started yet -> "future" -> private to the placed colleague + BM.
+        self.start = timezone.now().date() + datetime.timedelta(days=30)
+        self.placement = Placement.objects.create(
+            colleague=self.hidden_colleague,
+            service=self.service,
+            specific_start_date=self.start,
+            specific_end_date=self.start + datetime.timedelta(days=90),
+            period_source=Placement.PLACEMENT,
+            source="wies",
+        )
+        self.event = self._team_event(
+            [{"old": None, "new": self._row(self.service.id, "Software Engineer", "Hidden Colleague")}]
+        )
+
+    def _row(self, service_id, skill_name, colleague_name):
+        return {
+            "id": service_id,
+            "skill_name": skill_name,
+            "colleague_name": colleague_name,
+            "description": "",
+            "has_custom_period": False,
+            "start_date": self.start.isoformat(),
+            "end_date": (self.start + datetime.timedelta(days=90)).isoformat(),
+        }
+
+    def _team_event(self, changes):
+        return Event.objects.create(
+            user=self.owner_user,
+            user_email=self.owner_user.email,
+            object_type="Assignment",
+            action="update",
+            source="user",
+            object_id=self.assignment.id,
+            context={"field_name": "services", "field_label": "Team", "changes": changes},
+        )
+
+    def _get_timeline(self, user):
+        self.client.force_login(user)
+        return self.client.get(reverse("assignment-events-partial", args=[self.assignment.id]))
+
+    def test_hidden_colleague_name_not_leaked_to_unrelated_viewer(self):
+        response = self._get_timeline(self.unrelated_user)
+
+        assert response.status_code == 200
+        self.assertNotContains(response, "Hidden Colleague")
+
+    def test_event_dropped_entirely_when_all_changes_hidden(self):
+        """Dropped whole, so an empty 'wijzigde Team' cannot betray that a
+        hidden placement exists."""
+        response = self._get_timeline(self.unrelated_user)
+
+        self.assertNotContains(response, "Team")
+        self.assertContains(response, "Geen updates")
+
+    def test_bm_owner_still_sees_the_full_history(self):
+        response = self._get_timeline(self.owner_user)
+
+        self.assertContains(response, "Toegevoegd: Software Engineer (Hidden Colleague)")
+
+    def test_placed_colleague_sees_their_own_placement(self):
+        response = self._get_timeline(self.hidden_user)
+
+        self.assertContains(response, "Toegevoegd: Software Engineer (Hidden Colleague)")
+
+    def test_active_placement_name_stays_visible_to_everyone(self):
+        """The rule hides planned/ended placements only; an active one is public."""
+        Placement.objects.filter(pk=self.placement.pk).update(
+            specific_start_date=timezone.now().date() - datetime.timedelta(days=10),
+            specific_end_date=timezone.now().date() + datetime.timedelta(days=10),
+        )
+
+        response = self._get_timeline(self.unrelated_user)
+
+        self.assertContains(response, "Toegevoegd: Software Engineer (Hidden Colleague)")
+
+    def test_vacancy_change_stays_visible(self):
+        """A vacancy names nobody, so it has nothing to hide."""
+        self.event.delete()
+        vacancy_service = Service.objects.create(
+            description="", assignment=self.assignment, skill=Skill.objects.create(name="Communicatie"), source="wies"
+        )
+        self._team_event([{"old": None, "new": self._row(vacancy_service.id, "Communicatie Medewerker", None)}])
+
+        response = self._get_timeline(self.unrelated_user)
+
+        self.assertContains(response, "Toegevoegd: Communicatie Medewerker (open)")
+
+    def test_non_team_events_are_unaffected(self):
+        """Opdracht-level fields are on the Gegevens tab anyway."""
+        self.event.delete()
+        Event.objects.create(
+            user=self.owner_user,
+            user_email=self.owner_user.email,
+            object_type="Assignment",
+            action="update",
+            source="user",
+            object_id=self.assignment.id,
+            context={
+                "field_name": "name",
+                "field_label": "Opdracht naam",
+                "old_value": "UX / UI advies",
+                "new_value": "DTC4NL",
+            },
+        )
+
+        response = self._get_timeline(self.unrelated_user)
+
+        self.assertContains(response, 'van "UX / UI advies"')
 
 
 class AssignmentDeleteViewTests(TestCase):

--- a/wies/core/tests/test_assignment_views.py
+++ b/wies/core/tests/test_assignment_views.py
@@ -4,7 +4,9 @@ import importlib
 from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
+from django.db import connection
 from django.test import Client, TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 
@@ -890,6 +892,25 @@ class TimelinePlacementPrivacyTests(TestCase):
         response = self._get_timeline(self.unrelated_user)
 
         self.assertContains(response, "Toegevoegd: Communicatie Medewerker (open)")
+
+    def test_filter_does_not_query_per_event(self):
+        """The visible-name set is identical for every event in one request, so
+        it must be resolved once. Asserted as "does not grow with the number of
+        events" rather than a fixed count, which would break on any unrelated
+        query change."""
+        self.client.force_login(self.unrelated_user)
+        url = reverse("assignment-events-partial", args=[self.assignment.id])
+
+        with CaptureQueriesContext(connection) as one_event:
+            self.client.get(url)
+        for _ in range(9):
+            self._team_event(
+                [{"old": None, "new": self._row(self.service.id, "Software Engineer", "Hidden Colleague")}]
+            )
+        with CaptureQueriesContext(connection) as ten_events:
+            self.client.get(url)
+
+        assert len(ten_events.captured_queries) == len(one_event.captured_queries)
 
     def test_non_team_events_are_unaffected(self):
         """Opdracht-level fields are on the Gegevens tab anyway."""

--- a/wies/core/views.py
+++ b/wies/core/views.py
@@ -1996,34 +1996,52 @@ def assignment_events_partial(request, pk):
         .select_related("user__colleague")
         .order_by("-timestamp")[:20]
     )
-    for event in events:
-        _attach_audit_render_data(event)
+    events = [event for event in events if _attach_audit_render_data(event, assignment, request)]
     return render(request, "parts/assignment_events_timeline.html", {"events": events})
 
 
-def _attach_audit_render_data(event) -> None:
+def _attach_audit_render_data(event, obj, request) -> bool:
+    """Prepare `event` for the timeline. False means the viewer may see nothing
+    of it and it must not be rendered at all."""
     event.render_kind = "text"
     event.diff_entries = None
     event.formatted_old = event.context.get("old_value")
     event.formatted_new = event.context.get("new_value")
 
-    # Delete events are kept for the audit trail (visible in /beheer/database/)
-    # but never rendered here — a deleted opdracht has no panel to open.
+    # Delete events are kept for the audit trail but never rendered here — a
+    # deleted opdracht has no panel to open.
     if event.action != "update":
-        return
+        return True
     model_label = event.object_type.lower()
     editable_set = REGISTRY.get(model_label)
     if editable_set is None:
-        return
+        return True
     spec = editable_set._editables.get(event.context.get("field_name", ""))
     if spec is None:
-        return
+        return True
 
     if isinstance(spec, EditableCollection):
         event.render_kind = "collection"
+        changes = event.context.get("changes", [])
+        if spec.visible_changes is not None:
+            try:
+                visible = spec.visible_changes(obj, request, changes)
+            except AttributeError, TypeError:
+                # A legacy row shape the filter can't read is a row whose names
+                # we can't clear, so show no rows rather than risk a leak.
+                logger.warning(
+                    "Audit visible_changes failed for collection Event id=%s field=%s; hiding its rows",
+                    event.id,
+                    event.context.get("field_name"),
+                    exc_info=True,
+                )
+                return False
+            if changes and not visible:
+                return False
+            changes = visible
         if spec.render_change is not None:
             try:
-                event.diff_entries = [spec.render_change(c) for c in event.context.get("changes", [])]
+                event.diff_entries = [spec.render_change(c) for c in changes]
             except TypeError:
                 logger.warning(
                     "Audit render_change failed for collection Event id=%s field=%s; falling back to raw context",
@@ -2032,7 +2050,7 @@ def _attach_audit_render_data(event) -> None:
                     exc_info=True,
                 )
                 event.diff_entries = None
-        return
+        return True
 
     from django import forms  # noqa: PLC0415
 
@@ -2054,6 +2072,7 @@ def _attach_audit_render_data(event) -> None:
             event.context.get("field_name"),
             exc_info=True,
         )
+    return True
 
 
 def assignment_delete(request, pk):


### PR DESCRIPTION
Reported by a colleague: the opdracht **Updates** tab showed colleague names it should not.

## The leak

Wies has a deliberate privacy rule (`wies/core/placement_visibility.py`): a placement that is *currently active* is visible to everyone, but a **planned** or **ended** placement is private, visible only to the placed colleague and the BM-owner.

The Gegevens/Team tab honours this strictly. It even filters the team *count*, per the comment in `views.py`:

> `team_count comes from the same viewer-filtered rows the team list renders, so the header total can't betray a hidden placement.`

The Updates tab was a **second read path onto the same rows** that never inherited the rule. `audit_state` deliberately snapshots every placement including `colleague_name`, and `assignment_events_partial` rendered that snapshot verbatim to any authenticated user. So a name the Team tab carefully hid was shown in full one tab over, as `Toegevoegd: Software Engineer (<name>)`.

This is not an authentication gap: `LoginRequiredMiddleware` is active, and `test_events_partial_accessible_to_unrelated_user` records that the tab is intentionally open to all authenticated users. What was missing is the viewer filter on the Team rows inside it. Only `services` (Team) events leaked; opdracht-level fields (name, organizations, extra_info) are on the Gegevens tab anyway.

## The fix

A `visible_changes` hook on `EditableCollection`, implemented for the `services` collection to mirror `visible_service_rows`. The hook sits next to the existing rule rather than inline in the view, precisely because this incident shows what happens when a read path does not inherit it.

- A change survives only if **every** colleague name it mentions is one the viewer may already see on this opdracht. Vacancies name nobody and always survive.
- Keyed on the **name** in the snapshot, not the row id: the snapshot is frozen, so a row whose placement was since removed or re-filled would otherwise leak the earlier name.
- An event whose changes are all filtered out is **dropped whole**, not redacted to a placeholder, so the timeline cannot betray that a hidden placement exists. This matches how the Team tab drops rows and filters `team_count`.
- The BM-owner and the placed colleague keep the full history, so no audit value is lost for the people entitled to it.

## No data scrub

Render-time filtering only. `assignment_events_partial` is the only surface in the codebase that reads `Event` for display: there is no Django admin, and `staff_database` renders counts, not events. One filter closes the leak while the stored events keep the full trail for reproducibility. (Migration 0008 scrubbed *malformed* legacy data, a different case.) This PR also corrects the stale comment claiming delete events are visible in `/beheer/database/`.

## Verification

The evidence is in turning the fix **off**, not on:

| | with fix | without fix |
|---|---|---|
| 2 leak tests | pass | **fail**, reproducing the exact leaked line |
| 5 over-filtering guards (BM keeps history, active placement visible, vacancy visible, non-team events untouched) | pass | pass |

Full suite: 619 passed. Ruff and pre-commit clean.

## Known trade-off

The filter matches on the snapshot name. Two colleagues with an identical name, one of them visibly active on the opdracht, could unlock each other's team history. The name itself is already on screen in that case, so the marginal exposure is small. A `colleague_id` in the snapshot would be cleaner for new events, but the reported events are weeks old and lack that field, so the name path has to stay regardless. Happy to add the extra layer if wanted.