### PR TITLE
Quick security wins from the audit: logout-CSRF (F4) and CSV upload cap (F8)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ This files lists the changes during the lifetime of this project.
 ## unreleased
 
 - ?: x
+- ?: uitloggen kan alleen nog via de knop (POST), niet meer via een kaal GET-verzoek, zodat een externe pagina je niet ongemerkt kan uitloggen
 
 ## 2026-07-17
 

--- a/wies/core/tests/test_user_views.py
+++ b/wies/core/tests/test_user_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -680,6 +682,20 @@ class UserImportTest(TestCase):
         assert response.status_code == 200
         content = response.content.decode()
         assert "Geen bestand geüpload" in content
+
+    @patch("wies.core.views.MAX_CSV_UPLOAD_BYTES", 10)
+    def test_import_rejects_oversized_file(self):
+        """An upload above the size cap is rejected before it is read into memory
+        (audit F8)."""
+        self.client.force_login(self.auth_user)
+        big = self._create_csv_file("email,first_name,last_name\n" + "x" * 100)
+        before = User.objects.count()
+
+        response = self.client.post(self.import_url, {"csv_file": big})
+
+        assert response.status_code == 200
+        assert "te groot" in response.content.decode()
+        assert User.objects.count() == before
 
     def test_import_validates_csv_file_type(self):
         """Test that import validates file is a CSV"""

--- a/wies/core/views.py
+++ b/wies/core/views.py
@@ -1551,6 +1551,15 @@ def user_delete(request, pk):
     return HttpResponse(status=405)
 
 
+MAX_CSV_UPLOAD_BYTES = 2 * 1024 * 1024  # a user/opdracht CSV is far smaller than 2 MB
+_CSV_MAX_MB = MAX_CSV_UPLOAD_BYTES // (1024 * 1024)
+_CSV_TOO_LARGE_MSG = f"Bestand te groot. Upload een CSV-bestand van maximaal {_CSV_MAX_MB} MB."
+
+
+def _csv_too_large(csv_file) -> bool:
+    return bool(csv_file.size) and csv_file.size > MAX_CSV_UPLOAD_BYTES
+
+
 @permission_required("rijksauth.add_user", raise_exception=True)
 def user_import_csv(request):
     """
@@ -1578,6 +1587,13 @@ def user_import_csv(request):
                 request,
                 "user_import.html",
                 {"result": {"success": False, "errors": ["Ongeldig bestandstype. Upload een CSV-bestand."]}},
+            )
+
+        if _csv_too_large(csv_file):
+            return render(
+                request,
+                "user_import.html",
+                {"result": {"success": False, "errors": [_CSV_TOO_LARGE_MSG]}},
             )
 
         try:
@@ -1632,6 +1648,13 @@ def assignment_import_csv(request):
                 request,
                 "assignment_import.html",
                 {"result": {"success": False, "errors": ["Ongeldig bestandstype. Upload een CSV-bestand."]}},
+            )
+
+        if _csv_too_large(csv_file):
+            return render(
+                request,
+                "assignment_import.html",
+                {"result": {"success": False, "errors": [_CSV_TOO_LARGE_MSG]}},
             )
 
         try:

--- a/wies/rijksauth/tests/test_views.py
+++ b/wies/rijksauth/tests/test_views.py
@@ -94,7 +94,7 @@ class AuthViewsTest(TestCase):
         self.client.force_login(self.colleague)
         assert "_auth_user_id" in self.client.session
 
-        response = self.client.get(reverse("logout"))
+        response = self.client.post(reverse("logout"))
 
         assert response.status_code == 302
         assert response.url == "/inloggen/"
@@ -108,10 +108,17 @@ class AuthViewsTest(TestCase):
 
     def test_logout_when_not_logged_in(self):
         """Test logout works gracefully when user is not logged in"""
-        response = self.client.get(reverse("logout"))
+        response = self.client.post(reverse("logout"))
 
         assert response.status_code == 302
         assert response.url == "/inloggen/"
+
+    def test_logout_rejects_get(self):
+        """Logout must be POST-only: a GET (e.g. a cross-site <img src>) must not
+        log the user out (logout-CSRF, audit F4)."""
+        response = self.client.get(reverse("logout"))
+
+        assert response.status_code == 405
 
     @patch("wies.rijksauth.views._get_oidc")
     def test_logout_redirects_to_keycloak_end_session(self, mock_get_oidc):
@@ -124,7 +131,7 @@ class AuthViewsTest(TestCase):
         session["oidc_id_token"] = "fake-id-token"  # noqa: S105 (hardcoded-password) — test fixture, not a real token
         session.save()
 
-        response = self.client.get(reverse("logout"))
+        response = self.client.post(reverse("logout"))
 
         assert response.status_code == 302
         assert response.url.startswith("https://kc.example/realms/wies/protocol/openid-connect/logout?")

--- a/wies/rijksauth/views.py
+++ b/wies/rijksauth/views.py
@@ -10,6 +10,7 @@ from django.contrib.auth import logout as auth_logout
 from django.contrib.auth.decorators import login_not_required
 from django.shortcuts import redirect
 from django.urls import reverse, reverse_lazy
+from django.views.decorators.http import require_POST
 
 from .services.events import create_auth_event
 
@@ -71,6 +72,7 @@ def auth(request):
 
 
 @login_not_required
+@require_POST
 def logout(request):
     id_token = request.session.get(settings.OIDC_ID_TOKEN_SESSION_KEY)
     if request.user and request.user.is_authenticated:


### PR DESCRIPTION
Two clean, self-contained fixes from the security audit. (F9 and F11 were also on the quick-wins list but turned out to have real deployment/data nuance - see below - so they are deferred to their own focused changes.)

## F4 - logout is now POST-only (logout-CSRF)

`logout` was reachable by GET, so a cross-site `<img src=".../uitloggen/">` could force-log-out the victim. Added `@require_POST`. No UI change was needed: the profile and no-access pages already submit logout via a POST form with a CSRF token, and `onboarding_complete` is already POST-only. The OIDC RP-Initiated Logout redirect (to Keycloak's `end_session_endpoint`) is unchanged.

## F8 - CSV import upload size cap

`user_import_csv` and `assignment_import_csv` read the whole upload into memory with only a `.csv` suffix check, so a large file could exhaust a worker. Both now reject uploads over 2 MB (a real user/opdracht CSV is far smaller) before reading.

## Not included (deferred, with reasons)

- **F9** (assignment CSV bypasses the email-domain allowlist): the fix itself is small, but the allowlist rejects the out-of-domain example emails used throughout the fixtures - the user-facing `example_assignment_import.csv` template and many test CSVs across several files - and it needs a design call (gate only *minting* a new colleague, so an assignment CSV can still reference an existing OTYS-sourced colleague by its otys email). That is broader than a quick win; it deserves its own PR. Severity is low (one audit verifier rated it info: the app sends no email and never links these colleagues to accounts).
- **F11** (fail-open settings default + DB-password default): the `web` image is shared between local dev (`docker-compose.yml` builds `target: web`, used by `just up`) and production, so pinning `DJANGO_SETTINGS_MODULE=production` on it would break local dev. Fixing it properly needs a separate dev/prod image stage (the audit's BIO-12.5 item) or a deploy-side setting in ZAD/RIG-Cluster, neither of which is a quick in-repo change.

## Tests

New: `test_logout_rejects_get` (GET → 405) and `test_import_rejects_oversized_file` (over-cap upload rejected, no rows created). Existing logout tests updated from GET to POST. Full suite green.