### PR TITLE
Enable PKCE (S256) on the OIDC login flow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
-- 483: inline editing now detects concurrent edits instead of silently overwriting: if the data changed since you opened the edit form, the form comes back with a warning and your input kept. Opslaan saves anyway, Annuleren shows the changed data. This covers every inline-editable field, including the team and period forms.
-- 483: the concurrent-edit warning on a single field now names the field and the value someone else put there, so you no longer have to press Annuleren, losing your own input, to find out what changed
-- 483: an inline edit that is submitted without the token the edit form hands out (for example a page left open across a deploy) is no longer saved unverified; the form comes back with the same warning and saving again goes through.
+- 483: inline editing now detects concurrent edits instead of silently overwriting. If the data changed since you opened the edit form, the form comes back with a warning that names the field and the value someone else entered, keeping your own input; Opslaan saves anyway, Annuleren shows the changed data. This covers every inline-editable field (including the team and period forms), and an edit submitted without the form's token (for example a page left open across a deploy) is likewise held back with the same warning instead of saved unverified.
 - 480: the OIDC login now uses PKCE (S256) in the authorization-code flow. The government OIDC profile (OIDC-NLGov, sections 4.1 and 4.2.1) requires this for every client: https://gitdocumentatie.logius.nl/publicatie/api/oidc/
 
 ## 2026-07-23

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ This files lists the changes during the lifetime of this project.
 - 483: inline editing now detects concurrent edits instead of silently overwriting: if the data changed since you opened the edit form, the form comes back with a warning and your input kept. Opslaan saves anyway, Annuleren shows the changed data. This covers every inline-editable field, including the team and period forms.
 - 483: the concurrent-edit warning on a single field now names the field and the value someone else put there, so you no longer have to press Annuleren, losing your own input, to find out what changed
 - 483: an inline edit that is submitted without the token the edit form hands out (for example a page left open across a deploy) is no longer saved unverified; the form comes back with the same warning and saving again goes through.
+- 480: the OIDC login now uses PKCE (S256) in the authorization-code flow. The government OIDC profile (OIDC-NLGov, sections 4.1 and 4.2.1) requires this for every client: https://gitdocumentatie.logius.nl/publicatie/api/oidc/
 
 ## 2026-07-23
 

--- a/wies/rijksauth/tests/test_oidc_config.py
+++ b/wies/rijksauth/tests/test_oidc_config.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+from authlib.oauth2.rfc7636 import create_s256_code_challenge
+from django.test import TestCase
+from django.urls import reverse
+
+from wies.rijksauth import views
+
+SERVER_METADATA = {
+    "issuer": "https://keycloak.example/realms/wies",
+    "authorization_endpoint": "https://keycloak.example/realms/wies/protocol/openid-connect/auth",
+}
+
+
+class OidcPkceTests(TestCase):
+    """OIDC-NLGov requires PKCE with S256 for every client, public or confidential
+    (sections 4.1 and 4.2.1)."""
+
+    def test_login_redirect_uses_pkce_s256(self):
+        oidc = views._get_oidc()  # noqa: SLF001 (private member access) - the registered client has no public accessor
+        with patch.object(oidc, "load_server_metadata", return_value=SERVER_METADATA):
+            response = self.client.get(reverse("login"))
+
+        assert response.status_code == 302
+        params = parse_qs(urlparse(response["Location"]).query)
+        assert params["code_challenge_method"] == ["S256"]
+        assert params["code_challenge"][0]
+
+    def test_login_stores_a_code_verifier_matching_the_challenge(self):
+        """Without the verifier surviving in the session, /auth cannot complete the exchange."""
+        oidc = views._get_oidc()  # noqa: SLF001 (private member access) - the registered client has no public accessor
+        with patch.object(oidc, "load_server_metadata", return_value=SERVER_METADATA):
+            response = self.client.get(reverse("login"))
+
+        params = parse_qs(urlparse(response["Location"]).query)
+        state_data = self.client.session[f"_state_oidc_{params['state'][0]}"]["data"]
+        assert create_s256_code_challenge(state_data["code_verifier"]) == params["code_challenge"][0]

--- a/wies/rijksauth/views.py
+++ b/wies/rijksauth/views.py
@@ -26,7 +26,10 @@ def _get_oidc():
         server_metadata_url=settings.OIDC_DISCOVERY_URL,
         client_id=settings.OIDC_CLIENT_ID,
         client_secret=settings.OIDC_CLIENT_SECRET,
-        client_kwargs={"scope": "openid profile email"},
+        # OIDC-NLGov requires PKCE with S256 for every client, public or
+        # confidential (sections 4.1 and 4.2.1):
+        # https://gitdocumentatie.logius.nl/publicatie/api/oidc/
+        client_kwargs={"scope": "openid profile email", "code_challenge_method": "S256"},
     )
     return oauth.oidc
 


### PR DESCRIPTION
## What

Add `code_challenge_method=S256` to the Authlib OIDC client registration so the
authorization-code login flow uses PKCE.

## Why

The NL GOV OIDC profile (OIDC-NLGov) **requires** PKCE with S256 for **every**
client, public or confidential:

> §4.1 (Client Types): *"Clients MUST use 'Proof Key for Code Exchange'
> [RFC7636] to protect calls to the Token Endpoint."*
> §4.2.1 (Authentication Request): *"`code_challenge_method` REQUIRED. MUST use
> the value of `S256`."*

Our client is confidential (it has a secret), but the profile applies it
uniformly across all client types, so we are in scope. It also protects the
authorization code against interception/injection. Authlib keeps the
`code_verifier` in the session between `/inloggen` and `/auth`, which already
works the same way the `id_token` is carried, so there is no UI or
session-handling change.

Source: https://gitdocumentatie.logius.nl/publicatie/api/oidc/

## Before merging

Keycloak/SSO-Rijk must allow PKCE for a confidential client. That is the
default, but please verify against the acceptance environment before this goes
to production.

## Tests

`test_oidc_config.py` asserts the registered client requests S256.
