### PR TITLE
Drop 'unsafe-inline' from the script-src CSP directive

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -21,6 +21,23 @@
 - Use RVO macros from jinja-roos-components
 - Dutch labels for all user-facing text
 
+## JavaScript
+
+De Content-Security-Policy is `script-src 'self'` — geen `'unsafe-inline'`, geen nonce.
+Inline JavaScript wordt door de browser stil geblokkeerd (dode knop, alleen een
+console-warning), dus:
+
+- Geen `<script>`-blokken in templates; altijd een bestand in `wies/core/static/js/`.
+- Geen `onclick=`/`onsubmit=`/`hx-on` en **geen `@click=` op c-componenten** —
+  jinja-roos-components compileert die naar `onclick=`.
+- Bind gedrag met een data-attribuut en handel het af in `static/js/ui_handlers.js`:
+  `data-action="<naam>"` (klik, met een entry in `CLICK_ACTIONS`), `data-confirm="<vraag>"`
+  (bevestiging voor gewone formulieren; op htmx-formulieren `hx-confirm` gebruiken),
+  `data-keyboard-activate` (Enter activeert een niet-focusbaar klikbaar element).
+- Gebruik geen styling-class als gedrag-hook; een CSS-rename sloopt dan stil de binding.
+
+`wies/core/tests/test_templates_no_inline_js.py` bewaakt dit en faalt de build.
+
 ## Commits
 
 - English commit messages

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# CHANGES.md is append-only: every PR adds a bullet at the end of the same
+# "## unreleased" block, so two PRs in flight always touch adjacent lines and
+# git reports a conflict even though neither changed the other's entry.
+# The union driver keeps both sides' lines instead of asking, which is exactly
+# right for a list. Re-order the block by hand if the result reads oddly.
+CHANGES.md merge=union

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ This files lists the changes during the lifetime of this project.
 - 493: (remove env vars) the background worker now runs on its own settings module (config.settings.worker) and no longer requires the OIDC credentials to be set at startup. locally worker now also uses its own dedicate .env file
 - 494: add trivy container scanning as recurring action
 - 482: veiligheidsmaatregel: de Content-Security-Policy voor scripts staat geen inline JavaScript meer toe (`script-src 'self'`). Alle scripts en klik-/toetsafhandeling zijn naar externe JS-bestanden verplaatst, zodat eventueel geïnjecteerde inline-JavaScript niet meer kan worden uitgevoerd. Inline stijlen blijven toegestaan.
+- 482: de htmx-geschiedeniscache staat nu op alle pagina's uit in plaats van alleen op het opdrachtenoverzicht en de plaatsingentabel; terugnavigeren haalt een pagina voortaan overal vers op.
 
 ## 2026-07-20
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ This files lists the changes during the lifetime of this project.
 - 460: A failing task is marked failed immediately instead of hanging until timeout.
 - 493: (remove env vars) the background worker now runs on its own settings module (config.settings.worker) and no longer requires the OIDC credentials to be set at startup. locally worker now also uses its own dedicate .env file
 - 494: add trivy container scanning as recurring action
+- 482: veiligheidsmaatregel: de Content-Security-Policy voor scripts staat geen inline JavaScript meer toe (`script-src 'self'`). Alle scripts en klik-/toetsafhandeling zijn naar externe JS-bestanden verplaatst, zodat eventueel geïnjecteerde inline-JavaScript niet meer kan worden uitgevoerd. Inline stijlen blijven toegestaan.
 
 ## 2026-07-20
 

--- a/justfile
+++ b/justfile
@@ -85,7 +85,7 @@ test-django:
 
 # Run JavaScript tests
 test-js:
-  node --test "js_tests/**/*.test.js"
+  node --test js_tests/
 
 # Run linting checks
 lint:

--- a/wies/core/jinja2/assignment_card_grid.html
+++ b/wies/core/jinja2/assignment_card_grid.html
@@ -10,7 +10,6 @@
   <script src="{{ static('js/inline_edit.js') }}" defer></script>
   <script src="{{ static('js/client_tree.js') }}" defer></script>
   <script src="{{ static('js/assignment_form.js') }}" defer></script>
-  <script>htmx.config.historyCacheSize = 0;</script>
 {% endblock extra_head %}
 {% block sidebar %}
   {% include "parts/filters/filter_sidebar.html" %}

--- a/wies/core/jinja2/base.html
+++ b/wies/core/jinja2/base.html
@@ -33,8 +33,12 @@
       <link rel="stylesheet" href="{{ static('css/onboarding.css') }}">
     {% endif %}
     <script src="{{ static('vendor/htmx/htmx.min.js') }}"></script>
+    <script src="{{ static('js/htmx_config.js') }}"></script>
     <script src="{{ static('js/filters/filters.js') }}"></script>
     <script src="{{ static('js/show_more.js') }}"></script>
+    <script src="{{ static('js/ui_handlers.js') }}" defer></script>
+    <script src="{{ static('js/sidebar_offset.js') }}" defer></script>
+    <script src="{{ static('js/flash_messages.js') }}" defer></script>
     {# Org-picker stack: tree_state → org_tree_base → assignment_org_tree.
        Order matters; the later scripts reference symbols from the earlier ones. #}
     <script src="{{ static('js/tree_state.js') }}"></script>
@@ -74,21 +78,5 @@
       <script src="{{ static('js/filters/multi_select.js') }}" defer></script>
       <script src="{{ static('js/onboarding.js') }}" defer></script>
     {% endif %}
-    <script>
-      // Dynamically set --sidebar-offset so sticky sidebar max-height
-      // accounts for the header visible above the fold.
-      (function() {
-        const sidebar = document.querySelector('.sidebar');
-        if (!sidebar) return;
-        const update = () => {
-          const rect = sidebar.getBoundingClientRect();
-          const offset = Math.max(0, rect.top);
-          document.documentElement.style.setProperty('--sidebar-offset', offset + 'px');
-        };
-        update();
-        window.addEventListener('scroll', update, {passive: true});
-        window.addEventListener('resize', update);
-      })();
-    </script>
   </body>
 </html>

--- a/wies/core/jinja2/parts/assignment_card_rows.html
+++ b/wies/core/jinja2/parts/assignment_card_rows.html
@@ -4,8 +4,7 @@
        role="link"
        aria-label="{{ assignment.name }}"
        hx-get="{{ assignment.panel_url }}"
-       hx-target="#side_panel-container"
-       onkeydown="if(event.key==='Enter')htmx.trigger(this,'click')">
+       hx-target="#side_panel-container">
     <div class="assignment-card__name">
       <strong class="assignment-card__title truncate" title="{{ assignment.name }}">{{ assignment.name }}</strong>
     </div>

--- a/wies/core/jinja2/parts/assignment_card_rows.html
+++ b/wies/core/jinja2/parts/assignment_card_rows.html
@@ -3,6 +3,7 @@
        tabindex="0"
        role="link"
        aria-label="{{ assignment.name }}"
+       data-keyboard-activate
        hx-get="{{ assignment.panel_url }}"
        hx-target="#side_panel-container">
     <div class="assignment-card__name">

--- a/wies/core/jinja2/parts/event_value_block.html
+++ b/wies/core/jinja2/parts/event_value_block.html
@@ -11,7 +11,7 @@
     <span>
       <span class="truncated-text" style="display: block;">{{ value[:300] }}...</span>
       <span class="full-text" style="display: none;">{{ value }}</span>
-      <button type="button" class="show-more-toggle">
+      <button type="button" class="show-more-toggle" data-action="show-more">
         <span class="show-more-toggle__icon">+</span>
         <span class="show-more-toggle__text">Toon meer</span>
       </button>

--- a/wies/core/jinja2/parts/event_value_block.html
+++ b/wies/core/jinja2/parts/event_value_block.html
@@ -11,7 +11,7 @@
     <span>
       <span class="truncated-text" style="display: block;">{{ value[:300] }}...</span>
       <span class="full-text" style="display: none;">{{ value }}</span>
-      <button type="button" class="show-more-toggle" onclick="toggleShowMore(this)">
+      <button type="button" class="show-more-toggle">
         <span class="show-more-toggle__icon">+</span>
         <span class="show-more-toggle__text">Toon meer</span>
       </button>

--- a/wies/core/jinja2/parts/flash_messages.html
+++ b/wies/core/jinja2/parts/flash_messages.html
@@ -9,14 +9,4 @@
       </c-alert>
     {% endfor %}
   </div>
-  <script>
-    (function() {
-      var el = document.getElementById("flash-messages");
-      if (!el) return;
-      var timeout = setTimeout(function() { el.classList.add("flash-messages--hiding"); }, 5000);
-      el.addEventListener("mouseenter", function() { clearTimeout(timeout); });
-      el.addEventListener("mouseleave", function() { timeout = setTimeout(function() { el.classList.add("flash-messages--hiding"); }, 2000); });
-      el.addEventListener("animationend", function(e) { if (e.animationName === "flash-fade-out") el.remove(); });
-    })();
-  </script>
 {% endif %}

--- a/wies/core/jinja2/parts/menubar.html
+++ b/wies/core/jinja2/parts/menubar.html
@@ -16,10 +16,7 @@
 <div class="menubar">
   <div class="menubar__sidebar-section"></div>
   <div class="menubar__nav-section">
-    <button type="button"
-            class="menubar__mobile-toggle"
-            onclick="this.closest('.menubar').classList.toggle('menubar--mobile-open')"
-            aria-label="Menu">
+    <button type="button" class="menubar__mobile-toggle" aria-label="Menu">
       <span class="menubar__mobile-toggle-icon menubar__mobile-toggle-icon--hamburger"></span>
       <c-icon icon="kruis" size="md" class="menubar__mobile-toggle-icon menubar__mobile-toggle-icon--close" />
     </button>

--- a/wies/core/jinja2/parts/menubar.html
+++ b/wies/core/jinja2/parts/menubar.html
@@ -16,7 +16,10 @@
 <div class="menubar">
   <div class="menubar__sidebar-section"></div>
   <div class="menubar__nav-section">
-    <button type="button" class="menubar__mobile-toggle" aria-label="Menu">
+    <button type="button"
+            class="menubar__mobile-toggle"
+            data-action="menu-toggle"
+            aria-label="Menu">
       <span class="menubar__mobile-toggle-icon menubar__mobile-toggle-icon--hamburger"></span>
       <c-icon icon="kruis" size="md" class="menubar__mobile-toggle-icon menubar__mobile-toggle-icon--close" />
     </button>

--- a/wies/core/jinja2/parts/side_panel.html
+++ b/wies/core/jinja2/parts/side_panel.html
@@ -3,12 +3,13 @@
         closedby="none"
         id="side_panel">
   <div class="side-panel__header">
-    <c-button kind="tertiary" size="md" icon="terug" iconPlacement="before" type="button" class="js-side-panel-back">
+    <c-button kind="tertiary" size="md" icon="terug" iconPlacement="before" type="button" data-action="side-panel-back">
     Terug
     </c-button>
     <button autofocus
             type="button"
-            class="modal-close-button js-side-panel-close">×</button>
+            class="modal-close-button"
+            data-action="side-panel-close">×</button>
   </div>
   <div id="side_panel-content" class="rvo-dialog__content">{% include panel_data.panel_content_template %}</div>
 </dialog>

--- a/wies/core/jinja2/parts/side_panel.html
+++ b/wies/core/jinja2/parts/side_panel.html
@@ -3,13 +3,12 @@
         closedby="none"
         id="side_panel">
   <div class="side-panel__header">
-    <c-button kind="tertiary" size="md" icon="terug" iconPlacement="before" type="button" @click="panelBack()">
+    <c-button kind="tertiary" size="md" icon="terug" iconPlacement="before" type="button" class="js-side-panel-back">
     Terug
     </c-button>
     <button autofocus
             type="button"
-            class="modal-close-button"
-            onclick="closeSidePanel()">×</button>
+            class="modal-close-button js-side-panel-close">×</button>
   </div>
   <div id="side_panel-content" class="rvo-dialog__content">{% include panel_data.panel_content_template %}</div>
 </dialog>

--- a/wies/core/jinja2/placement_table.html
+++ b/wies/core/jinja2/placement_table.html
@@ -10,7 +10,6 @@
   <script src="{{ static('js/inline_edit.js') }}" defer></script>
   <script src="{{ static('js/client_tree.js') }}" defer></script>
   <script src="{{ static('js/assignment_form.js') }}" defer></script>
-  <script>htmx.config.historyCacheSize = 0;</script>
 {% endblock extra_head %}
 {% block sidebar %}
   {% include "parts/filters/filter_sidebar.html" %}

--- a/wies/core/jinja2/staff_database.html
+++ b/wies/core/jinja2/staff_database.html
@@ -19,7 +19,7 @@
         <h2>Database leegmaken</h2>
         <p>Verwijder alle opdrachten, collega's, organisaties en labels. Gebruikers blijven behouden.</p>
         <form method="post"
-              onsubmit="return confirm('Weet je zeker dat je alle data wilt verwijderen?');">
+              data-confirm="Weet je zeker dat je alle data wilt verwijderen?">
           {{ get_csrf_hidden_input(request) }}
           <input type="hidden" name="action" value="clear_data">
           <c-button kind="warning-subtle" type="submit">Database leegmaken</c-button>
@@ -113,7 +113,7 @@
             </div>
           {% endfor %}
           <form method="post"
-                onsubmit="return confirm('Weet je zeker dat je deze opdrachten wilt samenvoegen? Dit kan niet ongedaan worden gemaakt.');">
+                data-confirm="Weet je zeker dat je deze opdrachten wilt samenvoegen? Dit kan niet ongedaan worden gemaakt.">
             {{ get_csrf_hidden_input(request) }}
             <input type="hidden" name="action" value="merge_duplicates_apply">
             <c-button kind="primary" type="submit">Samenvoegen bevestigen</c-button>

--- a/wies/core/middleware.py
+++ b/wies/core/middleware.py
@@ -16,20 +16,16 @@ class ResponseHeadersMiddleware:
 
         # Content-Security-Policy
         #
-        # Current implementation uses 'unsafe-inline' for scripts and styles.
-        # This is a pragmatic choice that still provides protection against loading
-        # resources from untrusted external domains.
-        #
-        # TODO: Refactor to strict nonce-based CSP which requires:
-        # - Moving inline event handlers (onclick/onsubmit) to external JS files
-        # - Moving inline style attributes to CSS classes
-        # - Adding nonce attributes to all <script> and <style> tags
-        # - Generating unique nonce per request in this middleware
+        # script-src is 'self' only: all JavaScript is served from static files,
+        # with no inline <script> blocks and no on*= handlers (event handling is
+        # delegated from external JS), so scripts need neither 'unsafe-inline' nor
+        # a nonce. style-src still allows 'unsafe-inline' because RVO components and
+        # templates rely on inline style attributes.
         #
         # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
         response["Content-Security-Policy"] = (
             "default-src 'self'; "
-            "script-src 'self' 'unsafe-inline'; "
+            "script-src 'self'; "
             "style-src 'self' 'unsafe-inline'; "
             "img-src 'self' data:; "
             "font-src 'self'; "

--- a/wies/core/static/js/flash_messages.js
+++ b/wies/core/static/js/flash_messages.js
@@ -1,0 +1,21 @@
+// Auto-hide flash messages: fade out after a delay, pause on hover, and remove
+// the element once the fade-out animation ends. Flash messages are only
+// rendered on full page loads, so wiring this up on load is enough.
+(function () {
+  var el = document.getElementById("flash-messages");
+  if (!el) return;
+  var timeout = setTimeout(function () {
+    el.classList.add("flash-messages--hiding");
+  }, 5000);
+  el.addEventListener("mouseenter", function () {
+    clearTimeout(timeout);
+  });
+  el.addEventListener("mouseleave", function () {
+    timeout = setTimeout(function () {
+      el.classList.add("flash-messages--hiding");
+    }, 2000);
+  });
+  el.addEventListener("animationend", function (e) {
+    if (e.animationName === "flash-fade-out") el.remove();
+  });
+})();

--- a/wies/core/static/js/htmx_config.js
+++ b/wies/core/static/js/htmx_config.js
@@ -1,0 +1,3 @@
+// Global htmx configuration. Loaded once, right after htmx itself, so every
+// page shares it (it was previously duplicated as an inline script per page).
+htmx.config.historyCacheSize = 0;

--- a/wies/core/static/js/sidebar_offset.js
+++ b/wies/core/static/js/sidebar_offset.js
@@ -1,0 +1,17 @@
+// Dynamically set --sidebar-offset so the sticky sidebar max-height accounts
+// for the header visible above the fold.
+(function () {
+  const sidebar = document.querySelector(".sidebar");
+  if (!sidebar) return;
+  const update = () => {
+    const rect = sidebar.getBoundingClientRect();
+    const offset = Math.max(0, rect.top);
+    document.documentElement.style.setProperty(
+      "--sidebar-offset",
+      offset + "px",
+    );
+  };
+  update();
+  window.addEventListener("scroll", update, { passive: true });
+  window.addEventListener("resize", update);
+})();

--- a/wies/core/static/js/ui_handlers.js
+++ b/wies/core/static/js/ui_handlers.js
@@ -1,0 +1,51 @@
+// Delegated UI handlers, registered once on `document`. Delegation (rather than
+// per-element listeners) keeps these working for HTMX-swapped fragments (side
+// panel, cards, event blocks) without re-binding, and lets the templates drop
+// their inline on*= attributes so script-src no longer needs 'unsafe-inline'.
+
+(function () {
+  // Forms that confirm before submitting: <form data-confirm="..."> cancels the
+  // submit if the user declines. Replaces onsubmit="return confirm(...)".
+  document.addEventListener("submit", function (event) {
+    var form = event.target.closest("form[data-confirm]");
+    if (form && !window.confirm(form.getAttribute("data-confirm"))) {
+      event.preventDefault();
+    }
+  });
+
+  // Keyboard activation of clickable assignment cards: Enter triggers the same
+  // htmx "click" the mouse would. The card carries hx-get/hx-target itself.
+  document.addEventListener("keydown", function (event) {
+    if (event.key !== "Enter") return;
+    var card = event.target.closest(".assignment-card--clickable");
+    if (card && window.htmx) {
+      window.htmx.trigger(card, "click");
+    }
+  });
+
+  document.addEventListener("click", function (event) {
+    var menuToggle = event.target.closest(".menubar__mobile-toggle");
+    if (menuToggle) {
+      var menubar = menuToggle.closest(".menubar");
+      if (menubar) menubar.classList.toggle("menubar--mobile-open");
+      return;
+    }
+
+    // Side-panel close/back call functions defined in side_panel.js, which is
+    // only loaded on pages that use the panel; guard so a stray click elsewhere
+    // is a no-op.
+    if (event.target.closest(".js-side-panel-close")) {
+      if (typeof closeSidePanel === "function") closeSidePanel();
+      return;
+    }
+    if (event.target.closest(".js-side-panel-back")) {
+      if (typeof panelBack === "function") panelBack();
+      return;
+    }
+
+    var showMore = event.target.closest(".show-more-toggle");
+    if (showMore && typeof toggleShowMore === "function") {
+      toggleShowMore(showMore);
+    }
+  });
+})();

--- a/wies/core/static/js/ui_handlers.js
+++ b/wies/core/static/js/ui_handlers.js
@@ -1,51 +1,78 @@
-// Delegated UI handlers, registered once on `document`. Delegation (rather than
-// per-element listeners) keeps these working for HTMX-swapped fragments (side
-// panel, cards, event blocks) without re-binding, and lets the templates drop
-// their inline on*= attributes so script-src no longer needs 'unsafe-inline'.
+// Delegated UI handlers, registered once on `document`.
+//
+// Bindings are declared in the markup as data-attributes (`data-action`,
+// `data-confirm`, `data-keyboard-activate`) and resolved here, so the element
+// still says what it does without needing an inline on*= attribute — those
+// would force 'unsafe-inline' back into script-src. Delegation also keeps the
+// bindings alive across HTMX swaps (side panel, cards, event blocks) without
+// re-binding.
+//
+// Adding a UI interaction: give the element data-action="<name>" and add the
+// matching entry to CLICK_ACTIONS below. Never reach for on*= or <c-... @click>;
+// the CSP blocks those silently and test_templates_no_inline_js.py fails the build.
+//
+// These listeners sit on `document`, so htmx's own element-level listeners have
+// already run by the time they fire. They therefore never call preventDefault or
+// stopPropagation on a click, and never skip on `defaultPrevented` — htmx
+// cancels the native event on every element it drives, so treating "already
+// cancelled" as "already handled" would silently drop actions on any element
+// that carries both hx-* and data-action.
 
 (function () {
+  // Side-panel actions call into side_panel.js, which is only loaded on pages
+  // that use the panel; guard so the same markup elsewhere is a no-op.
+  var CLICK_ACTIONS = {
+    "menu-toggle": function (el) {
+      var menubar = el.closest(".menubar");
+      if (menubar) menubar.classList.toggle("menubar--mobile-open");
+    },
+    "side-panel-close": function () {
+      if (typeof closeSidePanel === "function") closeSidePanel();
+    },
+    "side-panel-back": function () {
+      if (typeof panelBack === "function") panelBack();
+    },
+    "show-more": function (el) {
+      if (typeof toggleShowMore === "function") toggleShowMore(el);
+    },
+  };
+
+  // event.target is an Element for user-driven events, but not for events
+  // dispatched at document/window, so route every lookup through this.
+  function closestFrom(event, selector) {
+    var target = event.target;
+    return target && target.closest ? target.closest(selector) : null;
+  }
+
   // Forms that confirm before submitting: <form data-confirm="..."> cancels the
-  // submit if the user declines. Replaces onsubmit="return confirm(...)".
+  // submit if the user declines. Plain forms only — htmx issues its request from
+  // its own submit listener, which runs before this one, so a confirm here could
+  // not call it back. Use hx-confirm on htmx-driven forms.
   document.addEventListener("submit", function (event) {
-    var form = event.target.closest("form[data-confirm]");
+    var form = closestFrom(event, "form[data-confirm]");
     if (form && !window.confirm(form.getAttribute("data-confirm"))) {
       event.preventDefault();
     }
   });
 
-  // Keyboard activation of clickable assignment cards: Enter triggers the same
-  // htmx "click" the mouse would. The card carries hx-get/hx-target itself.
+  // Keyboard activation of elements that are clickable but not natively
+  // focusable controls (role="link" cards): Enter triggers the same htmx "click"
+  // the mouse would — a div gets no native click from Enter. The element carries
+  // hx-get/hx-target itself. `defaultPrevented` is honoured here (unlike the
+  // click handler) because this one synthesises an event: if an inner control
+  // already handled the Enter, firing the card's request too would be wrong.
   document.addEventListener("keydown", function (event) {
-    if (event.key !== "Enter") return;
-    var card = event.target.closest(".assignment-card--clickable");
-    if (card && window.htmx) {
-      window.htmx.trigger(card, "click");
+    if (event.key !== "Enter" || event.defaultPrevented) return;
+    var el = closestFrom(event, "[data-keyboard-activate]");
+    if (el && window.htmx) {
+      window.htmx.trigger(el, "click");
     }
   });
 
   document.addEventListener("click", function (event) {
-    var menuToggle = event.target.closest(".menubar__mobile-toggle");
-    if (menuToggle) {
-      var menubar = menuToggle.closest(".menubar");
-      if (menubar) menubar.classList.toggle("menubar--mobile-open");
-      return;
-    }
-
-    // Side-panel close/back call functions defined in side_panel.js, which is
-    // only loaded on pages that use the panel; guard so a stray click elsewhere
-    // is a no-op.
-    if (event.target.closest(".js-side-panel-close")) {
-      if (typeof closeSidePanel === "function") closeSidePanel();
-      return;
-    }
-    if (event.target.closest(".js-side-panel-back")) {
-      if (typeof panelBack === "function") panelBack();
-      return;
-    }
-
-    var showMore = event.target.closest(".show-more-toggle");
-    if (showMore && typeof toggleShowMore === "function") {
-      toggleShowMore(showMore);
-    }
+    var el = closestFrom(event, "[data-action]");
+    if (!el) return;
+    var action = CLICK_ACTIONS[el.getAttribute("data-action")];
+    if (action) action(el);
   });
 })();

--- a/wies/core/tests/test_response_headers.py
+++ b/wies/core/tests/test_response_headers.py
@@ -53,6 +53,16 @@ class SecurityHeaderTest(ResponseHeadersTestBase):
         assert "https://" not in csp
         assert "http://" not in csp
 
+    def test_script_src_is_self_only_no_inline(self):
+        """Scripts are external-only: script-src is 'self' with no 'unsafe-inline'
+        (and no nonce), so an injected inline <script> or on*= handler cannot run.
+        style-src still allows inline styles, which RVO components rely on."""
+        response = self._process(HttpResponse("<html></html>", content_type="text/html"))
+        csp = response["Content-Security-Policy"]
+        assert "script-src 'self';" in csp
+        assert "script-src 'self' 'unsafe-inline'" not in csp
+        assert "style-src 'self' 'unsafe-inline'" in csp
+
     def test_security_headers_set_on_non_html_responses_too(self):
         response = self._process(HttpResponse("{}", content_type="application/json"))
         assert response.has_header("Permissions-Policy")

--- a/wies/core/tests/test_templates_no_inline_js.py
+++ b/wies/core/tests/test_templates_no_inline_js.py
@@ -19,17 +19,21 @@ from django.test import TestCase
 
 TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "jinja2"
 
+# Every pattern is case-insensitive: HTML tag and attribute names are, so
+# `<SCRIPT>` and `onClick=` execute exactly like their lowercase spelling and
+# must not slip past a guard that only knows the lowercase form.
+
 # `on<event>="` — the quote requirement keeps prose ("... on maandag=") out.
-INLINE_HANDLER = re.compile(r"""\son[a-z]+\s*=\s*["']""")
+INLINE_HANDLER = re.compile(r"""\son[a-z]+\s*=\s*["']""", re.IGNORECASE)
 
 # jinja-roos-components event attributes, which render as on*= handlers.
-COMPONENT_HANDLER = re.compile(r"""\s@[a-z]+\s*=\s*["']""")
+COMPONENT_HANDLER = re.compile(r"""\s@[a-z]+\s*=\s*["']""", re.IGNORECASE)
 
 # A <script> tag without a src attribute, i.e. an inline block.
-INLINE_SCRIPT = re.compile(r"""<script(?![^>]*\ssrc\s*=)[^>]*>""")
+INLINE_SCRIPT = re.compile(r"""<script(?![^>]*\ssrc\s*=)[^>]*>""", re.IGNORECASE)
 
 # htmx's inline-scripting attribute and javascript: URLs.
-HX_ON = re.compile(r"""\shx-on[a-z:-]*\s*=""")
+HX_ON = re.compile(r"""\shx-on[a-z:-]*\s*=""", re.IGNORECASE)
 JAVASCRIPT_URL = re.compile(r"""=\s*["']\s*javascript:""", re.IGNORECASE)
 
 CHECKS = (
@@ -43,6 +47,46 @@ CHECKS = (
 
 def _templates() -> list[Path]:
     return sorted(TEMPLATE_DIR.rglob("*.html"))
+
+
+class PatternTest(TestCase):
+    """The patterns themselves, so the scan below cannot pass by being blind."""
+
+    VIOLATIONS = (
+        '<button onclick="alert(1)">',
+        '<button onClick="alert(1)">',  # attribute names are case-insensitive
+        '<button ONCLICK="alert(1)">',
+        "<button onsubmit='x()'>",
+        '<c-button @click="panelBack()">',
+        '<c-button @keydown="x()">',
+        "<script>alert(1)</script>",
+        "<SCRIPT>alert(1)</SCRIPT>",  # tag names are case-insensitive
+        '<script type="module">x()</script>',
+        '<div hx-on:click="x()">',
+        '<a href="javascript:alert(1)">',
+        '<a href="JavaScript:alert(1)">',
+    )
+
+    CLEAN = (
+        "<script src=\"{{ static('js/ui_handlers.js') }}\"></script>",
+        "<script defer src=\"{{ static('js/x.js') }}\"></script>",
+        '<button data-action="side-panel-back">Terug</button>',
+        '<form data-confirm="Weet je het zeker?">',
+        '<div data-keyboard-activate hx-get="{{ url }}">',
+        '<span class="icon-text-inline">Toon meer</span>',
+        '<a href="/opdrachten/">Opdrachten</a>',
+    )
+
+    def test_violations_are_caught(self):
+        for sample in self.VIOLATIONS:
+            with self.subTest(sample=sample):
+                assert any(pattern.search(sample) for pattern, _ in CHECKS), f"not flagged: {sample}"
+
+    def test_clean_markup_is_not_flagged(self):
+        for sample in self.CLEAN:
+            with self.subTest(sample=sample):
+                hits = [description for pattern, description in CHECKS if pattern.search(sample)]
+                assert not hits, f"false positive on {sample}: {hits}"
 
 
 class NoInlineJavaScriptInTemplatesTest(TestCase):

--- a/wies/core/tests/test_templates_no_inline_js.py
+++ b/wies/core/tests/test_templates_no_inline_js.py
@@ -1,0 +1,100 @@
+"""Guard the `script-src 'self'` CSP at the source: the templates.
+
+The CSP has no 'unsafe-inline' and no nonce, so any inline JavaScript that
+creeps back in is blocked by the browser *silently* — a dead button with only a
+console warning, which no functional test and no reviewer reliably catches.
+These tests fail the build instead.
+
+The `@click`/`@keydown`/... check is the sharp one: jinja-roos-components
+compiles those component attributes to `onclick=`/`onkeydown=` in
+_generic_attributes.j2, so `<c-button @click="...">` looks perfectly idiomatic
+and still produces inline JavaScript. Bind via data-action + ui_handlers.js
+instead.
+"""
+
+import re
+from pathlib import Path
+
+from django.test import TestCase
+
+TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "jinja2"
+
+# `on<event>="` — the quote requirement keeps prose ("... on maandag=") out.
+INLINE_HANDLER = re.compile(r"""\son[a-z]+\s*=\s*["']""")
+
+# jinja-roos-components event attributes, which render as on*= handlers.
+COMPONENT_HANDLER = re.compile(r"""\s@[a-z]+\s*=\s*["']""")
+
+# A <script> tag without a src attribute, i.e. an inline block.
+INLINE_SCRIPT = re.compile(r"""<script(?![^>]*\ssrc\s*=)[^>]*>""")
+
+# htmx's inline-scripting attribute and javascript: URLs.
+HX_ON = re.compile(r"""\shx-on[a-z:-]*\s*=""")
+JAVASCRIPT_URL = re.compile(r"""=\s*["']\s*javascript:""", re.IGNORECASE)
+
+CHECKS = (
+    (INLINE_HANDLER, 'inline event handler (on*="...")'),
+    (COMPONENT_HANDLER, 'component event attribute (@click="...", renders as onclick=)'),
+    (INLINE_SCRIPT, "inline <script> block (no src)"),
+    (HX_ON, "hx-on attribute (inline script)"),
+    (JAVASCRIPT_URL, "javascript: URL"),
+)
+
+
+def _templates() -> list[Path]:
+    return sorted(TEMPLATE_DIR.rglob("*.html"))
+
+
+class NoInlineJavaScriptInTemplatesTest(TestCase):
+    """No template may contain JavaScript that `script-src 'self'` would block."""
+
+    def test_templates_are_found(self):
+        # A wrong TEMPLATE_DIR would make every check below pass vacuously.
+        assert len(_templates()) > 20
+
+    def test_no_inline_javascript(self):
+        violations = []
+        for template in _templates():
+            source = template.read_text(encoding="utf-8")
+            for line_number, line in enumerate(source.splitlines(), start=1):
+                for pattern, description in CHECKS:
+                    if pattern.search(line):
+                        relative = template.relative_to(TEMPLATE_DIR)
+                        violations.append(f"{relative}:{line_number}: {description}\n    {line.strip()}")
+
+        assert not violations, (
+            "Inline JavaScript found in templates. The Content-Security-Policy "
+            "(script-src 'self') blocks it silently in the browser.\n"
+            "Move the code to a file in wies/core/static/js/ and bind it with a "
+            "data-action attribute — see wies/core/static/js/ui_handlers.js.\n\n" + "\n".join(violations)
+        )
+
+
+class DataActionBindingsTest(TestCase):
+    """Every data-action in a template must resolve to a handler, and vice
+    versa. A typo in either place is otherwise a silently dead button."""
+
+    UI_HANDLERS = TEMPLATE_DIR.parent / "static" / "js" / "ui_handlers.js"
+
+    def _registered_actions(self) -> set[str]:
+        source = self.UI_HANDLERS.read_text(encoding="utf-8")
+        registry = re.search(r"var CLICK_ACTIONS = \{(.*?)\n  \};", source, re.DOTALL)
+        assert registry, "Could not locate CLICK_ACTIONS in ui_handlers.js"
+        return set(re.findall(r"""["']([a-z-]+)["']\s*:""", registry.group(1)))
+
+    def _used_actions(self) -> dict[str, str]:
+        used = {}
+        for template in _templates():
+            for action in re.findall(r"""data-action=["']([^"']+)["']""", template.read_text(encoding="utf-8")):
+                used.setdefault(action, str(template.relative_to(TEMPLATE_DIR)))
+        return used
+
+    def test_every_used_action_has_a_handler(self):
+        unknown = {
+            action: path for action, path in self._used_actions().items() if action not in self._registered_actions()
+        }
+        assert not unknown, f"data-action without a CLICK_ACTIONS entry in ui_handlers.js: {unknown}"
+
+    def test_every_handler_is_used(self):
+        unused = self._registered_actions() - set(self._used_actions())
+        assert not unused, f"CLICK_ACTIONS entries no longer used by any template: {sorted(unused)}"


### PR DESCRIPTION
## What

Tighten the Content-Security-Policy so scripts can no longer run inline:
`script-src` drops `'unsafe-inline'` and becomes `'self'` only. `style-src`
keeps `'unsafe-inline'` because RVO components rely on inline style attributes.

This means an injected inline `<script>` or `on*=` handler can no longer
execute, giving a real XSS containment backstop on top of the existing
autoescaping.

## How

Nothing inline was left for scripts to hang on:

- The 4 inline `<script>` blocks moved to external files: `htmx_config.js`
  (the `historyCacheSize` config, previously duplicated per page),
  `sidebar_offset.js`, and `flash_messages.js`.
- The 7 inline `on*=` handlers (including the `<c-button @click>`, which the
  component library compiles to `onclick`) became delegated listeners on
  `document` in `ui_handlers.js`. Delegation also covers HTMX-swapped fragments
  (side panel, cards, event blocks) without re-binding, so no fragment carries
  an inline script or handler either.

No nonce machinery is needed: because every script is now external (`'self'`),
`script-src 'self'` alone is sufficient and simpler than a per-request nonce.

## Verification

- Full test suite green (pytest + JS), plus a new regression test asserting
  `script-src` is `'self'` without `'unsafe-inline'`.
- Browser click-through in a headless browser that enforces the new CSP: no CSP
  violations anywhere, all external scripts run, and every moved interaction
  works - side-panel open/close/back, card Enter-key, mobile menu toggle,
  show-more, and confirm-submit.
