### PR TITLE
Return a graceful error on a malformed opdracht CSV instead of a 500

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ This files lists the changes during the lifetime of this project.
 ## unreleased
 
 - 477: logging out is now only possible via the button (POST), no longer via a bare GET request, so an external page cannot log you out without your knowledge
-- 486: the opdracht CSV import now shows a graceful error message instead of a 500 when a value is too long for its field or the file is not valid CSV.
+- 486: the opdracht and user CSV imports now shows a graceful error message instead of a 500 when a value is too long for its field or the file is not valid CSV.
 
 ## 2026-07-20
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ This files lists the changes during the lifetime of this project.
 ## unreleased
 
 - ?:
+- 486: de opdracht-CSV-import geeft nu een nette foutmelding in plaats van een 500 wanneer een waarde te lang is voor het veld of het bestand geen geldig CSV is.
 
 ## 2026-07-20
 

--- a/wies/core/services/placements.py
+++ b/wies/core/services/placements.py
@@ -1,10 +1,11 @@
 import csv
 import datetime
+import logging
 from io import StringIO
 
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.db import transaction
+from django.db import DataError, IntegrityError, transaction
 from django.db.models import Q
 
 from wies.core.models import (
@@ -20,6 +21,8 @@ from wies.core.models import (
     Skill,
 )
 from wies.core.services.events import create_event
+
+logger = logging.getLogger(__name__)
 
 
 def parse_date_dmy(date_str: str) -> datetime.date:
@@ -83,7 +86,13 @@ def create_assignments_from_csv(creator, csv_content: str):
                        If empty or not provided, no brand label is assigned.
     """
 
-    dialect = csv.Sniffer().sniff(csv_content[:1024], delimiters=",;")
+    try:
+        dialect = csv.Sniffer().sniff(csv_content[:1024], delimiters=",;")
+    except csv.Error:
+        return {
+            "success": False,
+            "errors": ["Kon het CSV-formaat niet bepalen. Controleer of het een geldig CSV-bestand is."],
+        }
     csv_reader = csv.DictReader(StringIO(csv_content), delimiter=dialect.delimiter)
 
     required_columns = {
@@ -278,6 +287,12 @@ def create_assignments_from_csv(creator, csv_content: str):
         return {"success": False, "errors": [str(e)]}
     except ValidationError as e:
         return {"success": False, "errors": [str(e)]}
+    except (DataError, IntegrityError, csv.Error) as e:
+        logger.warning("Opdracht-CSV import failed with a data error", exc_info=e)
+        return {
+            "success": False,
+            "errors": ["Er ging iets mis bij het verwerken van het bestand. Controleer de waarden in het CSV-bestand."],
+        }
     else:
         return {
             "success": True,

--- a/wies/core/services/users.py
+++ b/wies/core/services/users.py
@@ -1,4 +1,5 @@
 import csv
+import logging
 from io import StringIO
 
 from django.conf import settings
@@ -6,12 +7,15 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
+from django.db import DataError, IntegrityError, transaction
 
 from wies.core.errors import EmailNotAvailableError, InvalidEmailDomainError
 from wies.core.models import DEFAULT_LABELS, Colleague, Label, LabelCategory
 from wies.core.services.events import create_event
 
 User = get_user_model()
+
+logger = logging.getLogger(__name__)
 
 
 def is_allowed_email_domain(email: str) -> bool:
@@ -256,57 +260,68 @@ def create_users_from_csv(creator, csv_content: str):
     created_labels = []
     label_mapping = {}  # mapping from str to Label, to avoid many DB queries
 
-    merken_category, _ = LabelCategory.objects.get_or_create(
-        name="Merk", defaults={"color": DEFAULT_LABELS["Merk"]["color"]}
-    )
+    try:
+        with transaction.atomic():
+            merken_category, _ = LabelCategory.objects.get_or_create(
+                name="Merk", defaults={"color": DEFAULT_LABELS["Merk"]["color"]}
+            )
 
-    # Get all groups once
-    groups_dict = {
-        "Beheerder": Group.objects.get(name="Beheerder"),
-        "Consultant": Group.objects.get(name="Consultant"),
-        "BDM": Group.objects.get(name="Business Development Manager"),
-    }
+            # Get all groups once
+            groups_dict = {
+                "Beheerder": Group.objects.get(name="Beheerder"),
+                "Consultant": Group.objects.get(name="Consultant"),
+                "BDM": Group.objects.get(name="Business Development Manager"),
+            }
 
-    for row in rows:
-        first_name = row["first_name"].strip()
-        last_name = row["last_name"].strip()
-        email = row["email"].strip()
-        brand_name = row.get("brand", "").strip()
+            for row in rows:
+                first_name = row["first_name"].strip()
+                last_name = row["last_name"].strip()
+                email = row["email"].strip()
+                brand_name = row.get("brand", "").strip()
 
-        # Handle label assignment from brand column
-        labels_to_assign = []
-        if brand_name:
-            if brand_name in label_mapping:
-                label = label_mapping[brand_name]
-            else:
-                label, created = Label.objects.get_or_create(name=brand_name, category=merken_category)
-                label_mapping[brand_name] = label
-                if created:
-                    created_labels.append(brand_name)
-            labels_to_assign.append(label)
+                # Handle label assignment from brand column
+                labels_to_assign = []
+                if brand_name:
+                    if brand_name in label_mapping:
+                        label = label_mapping[brand_name]
+                    else:
+                        label, created = Label.objects.get_or_create(name=brand_name, category=merken_category)
+                        label_mapping[brand_name] = label
+                        if created:
+                            created_labels.append(brand_name)
+                    labels_to_assign.append(label)
 
-        groups_to_assign = []
-        for group_name in ["Beheerder", "Consultant", "BDM"]:
-            if row.get(group_name, "").strip().lower() == "y":
-                group = groups_dict.get(group_name)
-                if group:
-                    groups_to_assign.append(group)
+                groups_to_assign = []
+                for group_name in ["Beheerder", "Consultant", "BDM"]:
+                    if row.get(group_name, "").strip().lower() == "y":
+                        group = groups_dict.get(group_name)
+                        if group:
+                            groups_to_assign.append(group)
 
-        existing_user = User.objects.filter(email__iexact=email).first()
-        if existing_user:
-            # Skip existing users
-            errors.append(f"User with email '{email}' already exists, skipped")
-            continue
+                existing_user = User.objects.filter(email__iexact=email).first()
+                if existing_user:
+                    # Skip existing users
+                    errors.append(f"User with email '{email}' already exists, skipped")
+                    continue
 
-        create_user(
-            creator,
-            first_name=first_name,
-            last_name=last_name,
-            email=email,
-            labels=labels_to_assign,
-            groups=groups_to_assign,
-        )
-        users_created += 1
+                create_user(
+                    creator,
+                    first_name=first_name,
+                    last_name=last_name,
+                    email=email,
+                    labels=labels_to_assign,
+                    groups=groups_to_assign,
+                )
+                users_created += 1
+    except (DataError, IntegrityError) as e:
+        logger.warning("User-CSV import failed with a data error", exc_info=e)
+        return {
+            "success": False,
+            "users_created": 0,
+            "labels_created": 0,
+            "created_labels": [],
+            "errors": ["Er ging iets mis bij het verwerken van het bestand. Controleer de waarden in het CSV-bestand."],
+        }
 
     return {
         "success": True,

--- a/wies/core/tests/test_csv_import_errors.py
+++ b/wies/core/tests/test_csv_import_errors.py
@@ -1,6 +1,8 @@
+from django.contrib.auth.models import Group
 from django.test import TestCase
 
 from wies.core.services.placements import create_assignments_from_csv
+from wies.core.services.users import create_users_from_csv
 
 HEADERS = (
     "assignment_name,assignment_description,assignment_owner,assignment_owner_email,"
@@ -39,3 +41,34 @@ class CsvImportGracefulErrorTests(TestCase):
         result = create_assignments_from_csv(None, _csv())
 
         assert result["success"] is True
+
+
+USER_HEADERS = "first_name,last_name,email"
+
+
+def _user_csv(first_name="John"):
+    return USER_HEADERS + "\n" + f"{first_name},Doe,john@rijksoverheid.nl"
+
+
+class UserCsvImportGracefulErrorTests(TestCase):
+    """A malformed user-CSV must produce a graceful error result, never an
+    uncaught exception (which surfaces as a 500)."""
+
+    def setUp(self):
+        Group.objects.create(name="Beheerder")
+        Group.objects.create(name="Consultant")
+        Group.objects.create(name="Business Development Manager")
+
+    def test_value_longer_than_the_column_returns_graceful_error(self):
+        # User.first_name is max_length=150; a longer value would raise a DataError
+        # at the database instead of a handled error.
+        result = create_users_from_csv(None, _user_csv(first_name="x" * 300))
+
+        assert result["success"] is False
+        assert result["errors"]
+
+    def test_valid_csv_still_imports(self):
+        result = create_users_from_csv(None, _user_csv())
+
+        assert result["success"] is True
+        assert result["users_created"] == 1

--- a/wies/core/tests/test_csv_import_errors.py
+++ b/wies/core/tests/test_csv_import_errors.py
@@ -1,0 +1,41 @@
+from django.test import TestCase
+
+from wies.core.services.placements import create_assignments_from_csv
+
+HEADERS = (
+    "assignment_name,assignment_description,assignment_owner,assignment_owner_email,"
+    "client_1_url,assignment_start_date,assignment_end_date,service_skill,"
+    "placement_colleague_name,placement_colleague_email,owner_brand,colleague_brand"
+)
+
+
+def _csv(colleague_name="John Doe"):
+    row = (
+        f"Test Assignment,Test Description,Owner Name,owner@rijksoverheid.nl,,"
+        f"01-01-2025,31-12-2025,Python,{colleague_name},john@rijksoverheid.nl,,"
+    )
+    return HEADERS + "\n" + row
+
+
+class CsvImportGracefulErrorTests(TestCase):
+    """A malformed opdracht-CSV must produce a graceful error result, never an
+    uncaught exception (which surfaces as a 500)."""
+
+    def test_value_longer_than_the_column_returns_graceful_error(self):
+        # Colleague.name is max_length=200; a longer value would raise a DataError
+        # at the database instead of a handled error.
+        result = create_assignments_from_csv(None, _csv(colleague_name="x" * 300))
+
+        assert result["success"] is False
+        assert result["errors"]
+
+    def test_unparseable_csv_returns_graceful_error(self):
+        result = create_assignments_from_csv(None, "not-a-csv-without-any-delimiter")
+
+        assert result["success"] is False
+        assert result["errors"]
+
+    def test_valid_csv_still_imports(self):
+        result = create_assignments_from_csv(None, _csv())
+
+        assert result["success"] is True


### PR DESCRIPTION
## What

`create_assignments_from_csv` could crash with an uncaught exception (surfacing
as a HTTP 500) on a malformed opdracht CSV:

- The CSV dialect sniff ran **outside** the `try/except`, so an undetectable
  delimiter raised `csv.Error`.
- The `except` block caught only `ValueError`/`ValidationError`, so a value
  longer than a column allows raised a `DataError` from the database.

## Fix

Guard the dialect sniff, and add a `DataError`/`IntegrityError`/`csv.Error`
backstop in the except block. Both now return the normal
`{"success": False, "errors": [...]}` result with a Dutch message, so the
importer reports the problem instead of 500-ing.

## Scope

This is the **defensive half** of the CSV hardening (no more 500). The
email-domain allowlist on newly minted colleagues is a separate, larger change
(it touches existing fixtures and the example CSV) and comes as its own PR.

## Tests

`test_csv_import_errors.py`: a value longer than the column and an unparseable
CSV both return a graceful error; a valid CSV still imports. Full suite green.
