### PR TITLE
Hide excluded-org (intelligence-service) opdrachten from the panel and events/delete routes too

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ This files lists the changes during the lifetime of this project.
 ## unreleased
 
 - ?:
+- 489: opdrachten van uitgesloten organisaties (zoals inlichtingendiensten) zijn nu ook via het zijpaneel en de updates-/verwijder-routes onbereikbaar, niet alleen verborgen uit de lijsten; ze waren nog op te vragen door het id te raden.
 
 ## 2026-07-20
 

--- a/wies/core/tests/test_excluded_org_panel.py
+++ b/wies/core/tests/test_excluded_org_panel.py
@@ -1,0 +1,45 @@
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from wies.core.models import Assignment, AssignmentOrganizationUnit, Colleague, OrganizationUnit
+
+User = get_user_model()
+
+
+class ExcludedOrgPanelTests(TestCase):
+    """An assignment linked to an excluded (intelligence-service) organization is
+    hidden from every list; it must be equally unreachable via the side panel and
+    the events/delete routes, so it can't be viewed by guessing its id."""
+
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(email="u@rijksoverheid.nl", first_name="U", last_name="s")
+        self.colleague = Colleague.objects.create(user=self.user, name="U s", email="u@rijksoverheid.nl", source="wies")
+        self.client.force_login(self.user)
+
+        secret_org = OrganizationUnit.objects.create(
+            name="Algemene Inlichtingen- en Veiligheidsdienst", abbreviations=["AIVD"]
+        )
+        normal_org = OrganizationUnit.objects.create(name="Ministerie van Test", abbreviations=["MvT"])
+
+        self.secret = Assignment.objects.create(name="Geheime Opdracht", owner=self.colleague, source="wies")
+        AssignmentOrganizationUnit.objects.create(assignment=self.secret, organization=secret_org)
+        self.normal = Assignment.objects.create(name="Gewone Opdracht", owner=self.colleague, source="wies")
+        AssignmentOrganizationUnit.objects.create(assignment=self.normal, organization=normal_org)
+
+    def _home_panel(self, assignment):
+        return self.client.get(reverse("home"), {"opdracht": assignment.id})
+
+    def test_panel_hides_excluded_assignment(self):
+        self.assertNotContains(self._home_panel(self.secret), "Geheime Opdracht")
+
+    def test_panel_shows_normal_assignment(self):
+        self.assertContains(self._home_panel(self.normal), "Gewone Opdracht")
+
+    def test_events_route_is_404_for_excluded_assignment(self):
+        assert self.client.get(reverse("assignment-events-partial", args=[self.secret.id])).status_code == 404
+        assert self.client.get(reverse("assignment-events-partial", args=[self.normal.id])).status_code == 200
+
+    def test_delete_route_is_404_for_excluded_assignment(self):
+        assert self.client.get(reverse("assignment-delete", args=[self.secret.id])).status_code == 404

--- a/wies/core/views.py
+++ b/wies/core/views.py
@@ -156,6 +156,27 @@ def _build_assignment_panel_data(assignment, request):
     }
 
 
+def _assignment_hidden_by_org(assignment) -> bool:
+    """True when the assignment belongs to an excluded organization (e.g. an
+    intelligence service). Such assignments are hidden from every list, so they
+    must be equally unreachable via the side panel and the events/delete routes."""
+    excluded = get_excluded_org_ids()
+    return bool(excluded) and assignment.organizations.filter(id__in=excluded).exists()
+
+
+def _resolve_assignment_panel(request, assignment_id):
+    """Resolve the ?opdracht= side panel. Returns panel data, or None when the id
+    is malformed, the assignment does not exist, or it belongs to an excluded
+    organization."""
+    try:
+        assignment = Assignment.objects.select_related("owner").get(id=assignment_id)
+    except Assignment.DoesNotExist, ValueError, TypeError:
+        return None
+    if _assignment_hidden_by_org(assignment):
+        return None
+    return _build_assignment_panel_data(assignment, request)
+
+
 def _merge_date_range(existing: dict, start, end):
     """Widen the date range of an assignment entry to include the given start/end."""
     if start and (existing["start_date"] is None or start < existing["start_date"]):
@@ -374,6 +395,8 @@ def _resolve_placement_panel(request, placement_id):
     except Placement.DoesNotExist:
         return None
     assignment = placement.service.assignment
+    if _assignment_hidden_by_org(assignment):
+        return None
     viewer = getattr(request.user, "colleague", None)
     viewer_is_bm = viewer is not None and assignment.owner_id == viewer.id
     result = evaluate(
@@ -921,11 +944,9 @@ class PlacementListView(ListView):
             except Colleague.DoesNotExist:
                 pass
         elif assignment_id:
-            try:
-                assignment = Assignment.objects.get(id=assignment_id)
-                context["panel_data"] = _build_assignment_panel_data(assignment, self.request)
-            except Assignment.DoesNotExist:
-                pass
+            panel_data = _resolve_assignment_panel(self.request, assignment_id)
+            if panel_data is not None:
+                context["panel_data"] = panel_data
         return context
 
 
@@ -1196,11 +1217,9 @@ class AssignmentListView(ListView):
             except Colleague.DoesNotExist:
                 pass
         elif assignment_id:
-            try:
-                assignment = Assignment.objects.select_related("owner").get(id=assignment_id)
-                context["panel_data"] = _build_assignment_panel_data(assignment, self.request)
-            except Assignment.DoesNotExist:
-                pass
+            panel_data = _resolve_assignment_panel(self.request, assignment_id)
+            if panel_data is not None:
+                context["panel_data"] = panel_data
 
         return context
 
@@ -1988,6 +2007,8 @@ def label_delete(request, pk):
 
 def assignment_events_partial(request, pk):
     assignment = get_object_or_404(Assignment, pk=pk)
+    if _assignment_hidden_by_org(assignment):
+        raise Http404
     events = list(
         Event.objects.filter(
             object_type="Assignment",
@@ -2077,6 +2098,8 @@ def _attach_audit_render_data(event, obj, request) -> bool:
 
 def assignment_delete(request, pk):
     assignment = get_object_or_404(Assignment, pk=pk)
+    if _assignment_hidden_by_org(assignment):
+        raise Http404
     if not has_permission(Verb.DELETE, assignment, request.user):
         return HttpResponseForbidden()
 
@@ -2168,11 +2191,7 @@ def user_profile(request):
     if placement_id:
         panel_data = _resolve_placement_panel(request, placement_id)
     elif assignment_id:
-        try:
-            assignment = Assignment.objects.get(id=assignment_id)
-            panel_data = _build_assignment_panel_data(assignment, request)
-        except Assignment.DoesNotExist:
-            pass
+        panel_data = _resolve_assignment_panel(request, assignment_id)
     elif colleague_id:
         try:
             panel_colleague = Colleague.objects.get(id=colleague_id)


### PR DESCRIPTION
## What

Assignments linked to an **excluded organization** (e.g. an intelligence
service - `get_excluded_org_ids`, matching AIVD/MIVD and their descendants) are
filtered out of every list (Wie zit waar?, opdrachtenlijst, profiel, tellingen).
But the `?opdracht=` **side panel** and the **events/delete** routes resolved an
assignment by id *without* that filter, so a hidden assignment - its name,
client (= the service), period and active team - could still be opened by
guessing its id.

## Fix

Add a shared `_assignment_hidden_by_org()` check and a `_resolve_assignment_panel()`
helper, and apply the exclusion everywhere an assignment is resolved by id:

- the three `?opdracht=` panel sites (home, opdrachtenlijst, profiel),
- the placement panel (`?plaatsing=`, so a placement on a hidden opdracht is not
  a back door),
- `assignment_events_partial` and `assignment_delete` (now 404 for a hidden
  opdracht).

As a side effect the panel resolver returns no panel instead of an uncaught 500
for a malformed `?opdracht=` value.

## Scope

Colleague data and normal opdracht-metadata stay visible by design (internal RIG
tool); this only makes the *already-hidden* excluded-org category consistently
unreachable, matching what the lists already do.

## Tests

`test_excluded_org_panel.py`: an AIVD-linked opdracht is not shown via the panel
and returns 404 on the events/delete routes, while a normal opdracht still works.
Full suite green.
