### PR TITLE
Fix PR preview/cleanup race and decouple preview builds from CI state

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -4,11 +4,12 @@ on:
   pull_request:
     types: [closed]
 
-# Shares the PR Preview concurrency group, so closing a PR cancels any
-# in-flight preview run before cleanup; otherwise that run's deploy step
-# re-creates the ZAD deployment right after it was deleted here.
+# Shares the PR Preview concurrency group (named after the head branch), so
+# closing a PR cancels any in-flight preview run before cleanup; otherwise
+# that run's deploy step re-creates the ZAD deployment right after it was
+# deleted here.
 concurrency:
-  group: pr-preview-${{ github.event.pull_request.number }}
+  group: pr-preview-${{ github.event.pull_request.head.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -4,14 +4,6 @@ on:
   pull_request:
     types: [closed]
 
-# Shares the PR Preview concurrency group (named after the head branch), so
-# closing a PR cancels any in-flight preview run before cleanup; otherwise
-# that run's deploy step re-creates the ZAD deployment right after it was
-# deleted here.
-concurrency:
-  group: pr-preview-${{ github.event.pull_request.head.ref }}
-  cancel-in-progress: true
-
 env:
   IMAGE_TAG: pr-${{ github.event.pull_request.number }}
   DEPLOYMENT_NAME: pr-${{ github.event.pull_request.number }}
@@ -21,12 +13,39 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      actions: write
       contents: read
       deployments: write
       packages: write
       pull-requests: write
 
     steps:
+      # Cancel in-flight preview runs before deleting anything, or their deploy
+      # step re-creates the ZAD deployment right after it is removed here. This
+      # is an explicit API cancel rather than a shared concurrency group with
+      # PR Preview: a shared group cancels in both directions, so a push to the
+      # branch right after close would abort this cleanup mid-way. Manual
+      # dispatch runs (started from main) are invisible to the --branch filter;
+      # the deploy job's PR-open check covers those.
+      - name: Cancel in-flight preview runs for this branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          for STATUS in queued in_progress; do
+            gh run list --workflow "PR Preview" --branch "$HEAD_REF" \
+              --status "$STATUS" --json databaseId --jq '.[].databaseId'
+          done | while read -r RUN_ID; do
+            gh run cancel "$RUN_ID" || true  # run may have just finished on its own
+          done
+          for _ in $(seq 1 30); do
+            LEFT=$(gh run list --workflow "PR Preview" --branch "$HEAD_REF" \
+              --status in_progress --json databaseId --jq 'length')
+            [ "$LEFT" = "0" ] && exit 0
+            sleep 5
+          done
+          echo "::warning::Preview runs still cancelling after 150s; proceeding with cleanup"
+
       - name: Cleanup ZAD deployment and moving image tag
         continue-on-error: true
         uses: RijksICTGilde/zad-actions/cleanup@v4

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     types: [closed]
 
+# Shares the PR Preview concurrency group, so closing a PR cancels any
+# in-flight preview run before cleanup; otherwise that run's deploy step
+# re-creates the ZAD deployment right after it was deleted here.
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   IMAGE_TAG: pr-${{ github.event.pull_request.number }}
   DEPLOYMENT_NAME: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -2,20 +2,26 @@ name: PR Preview
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to rebuild and redeploy"
+        required: true
 
 concurrency:
-  group: pr-preview-${{ github.event.pull_request.number }}
+  group: pr-preview-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 env:
   IMAGE_NAME: ghcr.io/rijksictgilde/wies
-  MOVING_TAG: pr-${{ github.event.pull_request.number }}
-  DEPLOYMENT_NAME: pr-${{ github.event.pull_request.number }}
+  PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+  MOVING_TAG: pr-${{ github.event.pull_request.number || inputs.pr_number }}
+  DEPLOYMENT_NAME: pr-${{ github.event.pull_request.number || inputs.pr_number }}
 
 jobs:
   build:
-    if: github.event.pull_request.user.type != 'Bot' && github.event.pull_request.draft != true
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.user.type != 'Bot' && github.event.pull_request.draft != true)
     runs-on: ubuntu-latest
 
     permissions:
@@ -26,8 +32,13 @@ jobs:
       immutable_tag: ${{ steps.tag.outputs.immutable }}
 
     steps:
+      # Check out the PR head instead of the merge ref: the preview must
+      # build even when the PR has a merge conflict with main, and the
+      # merge ref does not exist on workflow_dispatch.
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ env.PR_NUMBER }}/head
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -40,8 +51,8 @@ jobs:
         id: tag
         run: |
           TIMESTAMP=$(date -u +%Y%m%d-%H%M%S)
-          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
-          IMMUTABLE="pr-${{ github.event.pull_request.number }}-${TIMESTAMP}-${SHORT_SHA}"
+          SHORT_SHA=$(git rev-parse HEAD | cut -c1-7)
+          IMMUTABLE="pr-${PR_NUMBER}-${TIMESTAMP}-${SHORT_SHA}"
           echo "immutable=${IMMUTABLE}" >> "$GITHUB_OUTPUT"
           echo "Immutable tag: ${IMMUTABLE}"
 
@@ -79,12 +90,26 @@ jobs:
       pull-requests: write
 
     environment:
-      name: pr-${{ github.event.pull_request.number }}
+      name: pr-${{ github.event.pull_request.number || inputs.pr_number }}
       url: ${{ steps.deploy.outputs.url }}
 
     steps:
+      # A PR can be merged while this run is in flight; deploying then
+      # would re-create the environment PR Cleanup just deleted.
+      - name: Check PR is still open
+        id: prstate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          STATE=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)
+          echo "state=${STATE}" >> "$GITHUB_OUTPUT"
+          if [ "${STATE}" != "open" ]; then
+            echo "::notice::PR ${PR_NUMBER} is ${STATE}; skipping deploy"
+          fi
+
       - name: Deploy to ZAD
         id: deploy
+        if: steps.prstate.outputs.state == 'open'
         uses: RijksICTGilde/zad-actions/deploy@v4
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,28 +1,105 @@
 name: PR Preview
 
+# Triggers deliberately avoid the plain pull_request event: GitHub silently
+# drops those when the PR has a merge conflict (no merge ref), leaving the
+# preview stuck on an old image. push always fires, and pull_request_target
+# (base-repo context) covers PR lifecycle moments without needing a merge ref.
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches-ignore: [main]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
         description: "PR number to rebuild and redeploy"
         required: true
 
+# Group name matches PR Cleanup's, so closing a PR cancels in-flight preview
+# runs (manual dispatch runs group by PR number instead; the deploy job's
+# PR-open check covers those).
 concurrency:
-  group: pr-preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  group: pr-preview-${{ github.head_ref || inputs.pr_number || github.ref_name }}
   cancel-in-progress: true
 
 env:
   IMAGE_NAME: ghcr.io/rijksictgilde/wies
-  PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-  MOVING_TAG: pr-${{ github.event.pull_request.number || inputs.pr_number }}
-  DEPLOYMENT_NAME: pr-${{ github.event.pull_request.number || inputs.pr_number }}
 
 jobs:
-  build:
-    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.user.type != 'Bot' && github.event.pull_request.draft != true)
+  context:
+    # pull_request_target runs with secrets in the base-repo context; never
+    # build code from a fork with it.
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      proceed: ${{ steps.pr.outputs.proceed }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+
+    steps:
+      - name: Find the open PR for this event
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          case "${GITHUB_EVENT_NAME}" in
+            push)
+              NUM=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$GITHUB_REF_NAME" \
+                --state open --json number --jq '.[0].number // empty')
+              ;;
+            pull_request_target)
+              NUM="$EVENT_PR_NUMBER"
+              ;;
+            workflow_dispatch)
+              NUM="$INPUT_PR_NUMBER"
+              ;;
+          esac
+
+          if [ -z "$NUM" ]; then
+            echo "::notice::No open PR for ${GITHUB_REF_NAME}; skipping preview"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! echo "$NUM" | grep -qE '^[0-9]+$'; then
+            echo "::error::Invalid PR number: $NUM"
+            exit 1
+          fi
+
+          PR=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${NUM}")
+          STATE=$(jq -r .state <<<"$PR")
+          DRAFT=$(jq -r .draft <<<"$PR")
+          BOT=$(jq -r '.user.type == "Bot"' <<<"$PR")
+          SHA=$(jq -r .head.sha <<<"$PR")
+
+          PROCEED=true
+          [ "$STATE" != "open" ] && PROCEED=false
+          # A manual dispatch is an explicit request; only event-driven runs
+          # skip drafts and bot PRs.
+          if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]; then
+            [ "$DRAFT" = "true" ] && PROCEED=false
+            [ "$BOT" = "true" ] && PROCEED=false
+          fi
+          if [ "$PROCEED" = "false" ]; then
+            echo "::notice::Skipping preview for PR #${NUM} (state=${STATE}, draft=${DRAFT}, bot=${BOT})"
+          fi
+
+          {
+            echo "proceed=${PROCEED}"
+            echo "pr_number=${NUM}"
+            echo "head_sha=${SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: context
+    if: needs.context.outputs.proceed == 'true'
 
     permissions:
       contents: read
@@ -32,13 +109,10 @@ jobs:
       immutable_tag: ${{ steps.tag.outputs.immutable }}
 
     steps:
-      # Check out the PR head instead of the merge ref: the preview must
-      # build even when the PR has a merge conflict with main, and the
-      # merge ref does not exist on workflow_dispatch.
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: refs/pull/${{ env.PR_NUMBER }}/head
+          ref: ${{ needs.context.outputs.head_sha }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -49,10 +123,12 @@ jobs:
 
       - name: Compute image tag
         id: tag
+        env:
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.context.outputs.head_sha }}
         run: |
           TIMESTAMP=$(date -u +%Y%m%d-%H%M%S)
-          SHORT_SHA=$(git rev-parse HEAD | cut -c1-7)
-          IMMUTABLE="pr-${PR_NUMBER}-${TIMESTAMP}-${SHORT_SHA}"
+          IMMUTABLE="pr-${PR_NUMBER}-${TIMESTAMP}-${HEAD_SHA:0:7}"
           echo "immutable=${IMMUTABLE}" >> "$GITHUB_OUTPUT"
           echo "Immutable tag: ${IMMUTABLE}"
 
@@ -65,7 +141,7 @@ jobs:
           build-args: |
             APP_VERSION=${{ steps.tag.outputs.immutable }}
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ env.MOVING_TAG }}
+            ${{ env.IMAGE_NAME }}:pr-${{ needs.context.outputs.pr_number }}
             ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.immutable }}
 
       - name: Build and push worker image
@@ -77,12 +153,12 @@ jobs:
           build-args: |
             APP_VERSION=${{ steps.tag.outputs.immutable }}
           tags: |
-            ${{ env.IMAGE_NAME }}-worker:${{ env.MOVING_TAG }}
+            ${{ env.IMAGE_NAME }}-worker:pr-${{ needs.context.outputs.pr_number }}
             ${{ env.IMAGE_NAME }}-worker:${{ steps.tag.outputs.immutable }}
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [context, build]
 
     permissions:
       contents: read
@@ -90,7 +166,7 @@ jobs:
       pull-requests: write
 
     environment:
-      name: pr-${{ github.event.pull_request.number || inputs.pr_number }}
+      name: pr-${{ needs.context.outputs.pr_number }}
       url: ${{ steps.deploy.outputs.url }}
 
     steps:
@@ -100,6 +176,7 @@ jobs:
         id: prstate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
         run: |
           STATE=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)
           echo "state=${STATE}" >> "$GITHUB_OUTPUT"
@@ -114,11 +191,34 @@ jobs:
         with:
           api-key: ${{ secrets.ZAD_API_KEY }}
           project-id: wies
-          deployment-name: ${{ env.DEPLOYMENT_NAME }}
+          deployment-name: pr-${{ needs.context.outputs.pr_number }}
           clone-from: main
-          comment-on-pr: true
           components: |
             [
               {"name": "frontend", "image": "${{ env.IMAGE_NAME }}:${{ needs.build.outputs.immutable_tag }}"},
               {"name": "worker", "image": "${{ env.IMAGE_NAME }}-worker:${{ needs.build.outputs.immutable_tag }}"}
             ]
+
+      # The zad action only posts the preview comment on pull_request events,
+      # which this workflow no longer uses. The header must stay identical to
+      # the one PR Cleanup deletes ("## 🚀 Preview Deployment").
+      - name: Comment preview URL on PR
+        if: steps.prstate.outputs.state == 'open'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.context.outputs.pr_number }}
+          URLS: ${{ steps.deploy.outputs.urls }}
+          IMMUTABLE_TAG: ${{ needs.build.outputs.immutable_tag }}
+          COMMENT_HEADER: "## 🚀 Preview Deployment"
+        run: |
+          LINKS=$(jq -r 'to_entries[] | "- **\(.key)**: \(.value)"' <<<"$URLS")
+          BODY=$(printf '%s\n\n%s\n\n_build: `%s`_' "$COMMENT_HEADER" "$LINKS" "$IMMUTABLE_TAG")
+          COMMENT_ID=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq "[.[] | select(.body | startswith(\"${COMMENT_HEADER}\")) | .id][0] // empty")
+          if [ -n "$COMMENT_ID" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" -f body="$BODY" >/dev/null
+            echo "Updated preview comment ${COMMENT_ID}"
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -f body="$BODY" >/dev/null
+            echo "Created preview comment"
+          fi

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -15,9 +15,9 @@ on:
         description: "PR number to rebuild and redeploy"
         required: true
 
-# Group name matches PR Cleanup's, so closing a PR cancels in-flight preview
-# runs (manual dispatch runs group by PR number instead; the deploy job's
-# PR-open check covers those).
+# Dedupes runs per branch (manual dispatch runs group by PR number instead).
+# On close, PR Cleanup cancels in-flight runs here via the API; the deploy
+# job's PR-open check covers runs it cannot see, such as manual dispatches.
 concurrency:
   group: pr-preview-${{ github.head_ref || inputs.pr_number || github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/pr-registry-gc.yml
+++ b/.github/workflows/pr-registry-gc.yml
@@ -19,7 +19,8 @@ jobs:
 
     steps:
       - name: Prune old PR container images
-        uses: snok/container-retention-policy@v3
+        # No moving v3 tag exists for this action; pin the exact release.
+        uses: snok/container-retention-policy@v3.1.0
         with:
           account: rijksictgilde
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
-- 491: PR preview environments are now reliably removed when a PR closes (closing cancels any in-flight preview run), preview images build on every push regardless of merge conflicts or CI status, previews also build when a draft PR is marked ready for review, and a preview can be rebuilt manually from the Actions UI
+- 491: PR preview environments are now reliably removed when a PR closes (closing cancels any in-flight preview run), preview images build on every push regardless of merge conflicts or CI status, previews also build when a draft PR is marked ready for review, and a preview can be rebuilt manually from the Actions UI; the weekly registry cleanup of old preview images is fixed (it referenced a non-existent action version and had never run)
 - 477: logging out is now only possible via the button (POST), no longer via a bare GET request, so an external page cannot log you out without your knowledge
 - 486: the opdracht and user CSV imports now shows a graceful error message instead of a 500 when a value is too long for its field or the file is not valid CSV.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
-- XXX: PR preview environments are now reliably removed when a PR closes (closing cancels any in-flight preview run), preview images build on every push regardless of merge conflicts or CI status, previews also build when a draft PR is marked ready for review, and a preview can be rebuilt manually from the Actions UI
+- 491: PR preview environments are now reliably removed when a PR closes (closing cancels any in-flight preview run), preview images build on every push regardless of merge conflicts or CI status, previews also build when a draft PR is marked ready for review, and a preview can be rebuilt manually from the Actions UI
 - 477: logging out is now only possible via the button (POST), no longer via a bare GET request, so an external page cannot log you out without your knowledge
 - 486: the opdracht and user CSV imports now shows a graceful error message instead of a 500 when a value is too long for its field or the file is not valid CSV.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
+- XXX: PR preview environments are now reliably removed when a PR closes (closing cancels any in-flight preview run), preview images build on every push regardless of merge conflicts or CI status, previews also build when a draft PR is marked ready for review, and a preview can be rebuilt manually from the Actions UI
 - 477: logging out is now only possible via the button (POST), no longer via a bare GET request, so an external page cannot log you out without your knowledge
 - 486: the opdracht and user CSV imports now shows a graceful error message instead of a 500 when a value is too long for its field or the file is not valid CSV.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ This files lists the changes during the lifetime of this project.
 
 ## unreleased
 
-- 491: PR preview environments are now reliably removed when a PR closes (closing cancels any in-flight preview run), preview images build on every push regardless of merge conflicts or CI status, previews also build when a draft PR is marked ready for review, and a preview can be rebuilt manually from the Actions UI; the weekly registry cleanup of old preview images is fixed (it referenced a non-existent action version and had never run)
+- 491: PR preview environments are now reliably removed when a PR closes, preview images build on every push regardless of merge conflicts or CI status, previews also build when a draft PR is marked ready for review, and a preview can be rebuilt manually from the Actions UI; the weekly registry cleanup of old preview images is fixed
 - 478: the user and opdracht CSV imports now reject files larger than 50 MB, so an extremely large file cannot exhaust a worker's memory
 - 477: logging out is now only possible via the button (POST), no longer via a bare GET request, so an external page cannot log you out without your knowledge
 - 481: the production container no longer silently falls back to the local development settings (DEBUG on) when DJANGO_SETTINGS_MODULE is missing at startup; the startup script then defaults to the production settings (an explicitly provided value still takes precedence). Local development is unchanged.


### PR DESCRIPTION
## Probleem

Van de 25 `pr-*` deployments op ZAD hoorden er 17 bij al gesloten PRs. De cleanup draaide in al die gevallen wél en verwijderde de deployment ook echt — maar er liep op dat moment nog een `PR Preview`-run (gestart door een laatste push of update-branch vlak voor de merge). Die run bereikte zijn deploy-stap ná de cleanup en zette de deployment weer terug. Bij 16 van de 17 stale deployments eindigde de laatste preview-run aantoonbaar na het sluiten van de PR. Hetzelfde mechanisme liet ook images achter in GHCR (8 van de 17 PRs).

Daarnaast (#382): previews bouwden niet op elke push. De kern daarvan bleek dat GitHub `pull_request`-events **helemaal niet aflevert** zolang een PR een merge-conflict met de base heeft (er is dan geen merge-ref) — geen enkele run, zonder foutmelding. Deze PR reproduceerde dat zelf: tot het conflict met main was opgelost draaide er niets, terwijl de `pull_request_target`-workflow (Label PRs) wél gewoon draaide.

## Oplossing

**Race gedicht:** `pr-cleanup.yml` cancelt als eerste stap expliciet elke lopende/wachtende `PR Preview`-run voor de head-branch (via `gh run cancel`) en wacht tot die echt gestopt is vóór er iets verwijderd wordt — er wordt geen image meer gebouwd of gedeployed voor een PR die net gemerged is. Bewust géén gedeelde concurrency-group tussen beide workflows: die cancelt in twee richtingen, waardoor een push naar de branch vlak na het sluiten de cleanup zelf halverwege zou afbreken, terwijl de push-run daarna zelf skipt (geen open PR meer) en niemand de cleanup afmaakt.

**Defense in depth:** de deploy-job checkt vlak vóór de ZAD-deploy of de PR nog open is en skipt anders (dekt ook handmatige runs af).

**Altijd kunnen bouwen (#382):** de preview triggert niet meer op `pull_request` maar op:
- `push` (alle branches behalve main) — wordt áltijd afgeleverd, conflict of niet. Een `context`-job zoekt de open PR bij de branch; zonder open PR (of bij draft/bot-PR) gebeurt er niets.
- `pull_request_target` voor `opened`/`reopened`/`ready_for_review` — vuurt ook bij conflicten (base-context, geen merge-ref nodig). Fork-PRs zijn expliciet uitgesloten (secrets!); een draft die op ready gezet wordt krijgt nu direct een preview.
- `workflow_dispatch` met PR-nummer, voor handmatig herbouwen vanuit de Actions UI.

Er wordt gebouwd van de head-SHA van de PR (niet de merge-ref), dus onafhankelijk van mergebaarheid, testresultaten, pre-commit of security-scans. De preview-URL-comment wordt nu door de workflow zelf geplaatst/geüpdatet (de zad-action doet dat alleen bij `pull_request`-events), met dezelfde header die `PR Cleanup` opruimt.

## Bonus: wekelijkse image-GC gerepareerd

`pr-registry-gc.yml` verwees naar `snok/container-retention-policy@v3`, maar die action heeft geen moving `v3`-tag — elke wekelijkse run faalde daardoor op "unable to find version v3". Nu gepind op `v3.1.0`. Dit verklaart waarom er nog preview-images uit april in GHCR staan; na de merge ruimt de eerstvolgende wekelijkse run (of een handmatige `workflow_dispatch`, evt. met `dry_run`) die alsnog op.

## Acceptatiecriteria uit #382

- [x] Op elke push naar een PR-branch start `PR Preview` een nieuwe run met de laatste SHA — ook bij merge-conflicten, falende tests, pre-commit of security-scans
- [x] De build/push-stap heeft geen dependency op andere checks
- [x] De deploy-stap idem (alleen een PR-is-nog-open-check, bewust)
- [x] `workflow_dispatch:` trigger toegevoegd
- [x] CHANGES.md bijgewerkt

De 17 bestaande stale deployments op ZAD worden apart handmatig opgeruimd.

Fixes #382

