### PR TITLE
Fix PR cleanup failing before it cleans anything up

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -28,20 +28,50 @@ jobs:
       # dispatch runs (started from main) are invisible to the --branch filter;
       # the deploy job's PR-open check covers those.
       - name: Cancel in-flight preview runs for this branch
+        # Best-effort, like the cleanup steps below: this step runs first, so
+        # letting it fail hard means nothing is cleaned up at all. The step
+        # already proceeds after a 150s cancel timeout; a transient API error
+        # should not be treated more harshly than that.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          for STATUS in queued in_progress; do
-            gh run list --workflow "PR Preview" --branch "$HEAD_REF" \
-              --status "$STATUS" --json databaseId --jq '.[].databaseId'
-          done | while read -r RUN_ID; do
-            gh run cancel "$RUN_ID" || true  # run may have just finished on its own
+          # Every gh call needs --repo: this job does not check the repository
+          # out, so gh cannot infer it and exits with "failed to determine base
+          # repo". Same reason pr-preview.yml passes --repo/$GITHUB_REPOSITORY.
+
+          # Active runs, both statuses, deduplicated: a run can move from queued
+          # to in_progress between the two queries and come back twice.
+          # gh is deliberately not piped here: in `for ... done | sort` the loop
+          # runs in a subshell, so a failing gh could not fail the function and
+          # a broken API would read as "nothing running".
+          list_active() {
+            ids=""
+            for STATUS in queued in_progress; do
+              out=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "PR Preview" \
+                --branch "$HEAD_REF" --status "$STATUS" \
+                --json databaseId --jq '.[].databaseId') || return 1
+              ids="${ids}${out}
+          "
+            done
+            printf '%s' "$ids" | sort -u | sed '/^[[:space:]]*$/d'
+          }
+
+          list_active | while read -r RUN_ID; do
+            # run may have just finished on its own
+            gh run cancel --repo "$GITHUB_REPOSITORY" "$RUN_ID" || true
           done
+
+          # Wait on queued as well as in_progress: a run that is still queued has
+          # not started its deploy step yet, so treating it as drained lets it
+          # start right after the cleanup and re-create what we just removed.
           for _ in $(seq 1 30); do
-            LEFT=$(gh run list --workflow "PR Preview" --branch "$HEAD_REF" \
-              --status in_progress --json databaseId --jq 'length')
-            [ "$LEFT" = "0" ] && exit 0
+            if ! ACTIVE=$(list_active); then
+              echo "::warning::Could not query preview runs; proceeding with cleanup"
+              exit 0
+            fi
+            [ -z "$ACTIVE" ] && exit 0
             sleep 5
           done
           echo "::warning::Preview runs still cancelling after 150s; proceeding with cleanup"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ This files lists the changes during the lifetime of this project.
 - 494: add trivy container scanning as recurring action
 - 482: veiligheidsmaatregel: de Content-Security-Policy voor scripts staat geen inline JavaScript meer toe (`script-src 'self'`). Alle scripts en klik-/toetsafhandeling zijn naar externe JS-bestanden verplaatst, zodat eventueel geïnjecteerde inline-JavaScript niet meer kan worden uitgevoerd. Inline stijlen blijven toegestaan.
 - 482: de htmx-geschiedeniscache staat nu op alle pagina's uit in plaats van alleen op het opdrachtenoverzicht en de plaatsingentabel; terugnavigeren haalt een pagina voortaan overal vers op.
+- PRNUM: fix the PR preview cleanup never running: its first step called `gh` without `--repo` in a job that has no checkout, so it failed immediately and the ZAD deployment and PR-tagged images of every closed PR were left behind
 
 ## 2026-07-20
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ This files lists the changes during the lifetime of this project.
 - 494: add trivy container scanning as recurring action
 - 482: veiligheidsmaatregel: de Content-Security-Policy voor scripts staat geen inline JavaScript meer toe (`script-src 'self'`). Alle scripts en klik-/toetsafhandeling zijn naar externe JS-bestanden verplaatst, zodat eventueel geïnjecteerde inline-JavaScript niet meer kan worden uitgevoerd. Inline stijlen blijven toegestaan.
 - 482: de htmx-geschiedeniscache staat nu op alle pagina's uit in plaats van alleen op het opdrachtenoverzicht en de plaatsingentabel; terugnavigeren haalt een pagina voortaan overal vers op.
-- PRNUM: fix the PR preview cleanup never running: its first step called `gh` without `--repo` in a job that has no checkout, so it failed immediately and the ZAD deployment and PR-tagged images of every closed PR were left behind
+- 496: fix the PR preview cleanup never running: its first step called `gh` without `--repo` in a job that has no checkout, so it failed immediately and the ZAD deployment and PR-tagged images of every closed PR were left behind
 
 ## 2026-07-20
 


### PR DESCRIPTION
## What

The PR preview cleanup has never run. Its first step fails within seconds, and because it has no `continue-on-error`, the job aborts there — so the two steps that actually clean up never execute.

Concretely: every closed PR leaves its ZAD deployment and its `pr-<n>`/`pr-<n>-*` container images behind. The last six runs of `PR Cleanup` are all red, across unrelated branches:

```
failure  fix/csp-drop-unsafe-inline-scripts
failure  silence-unfixed-trivy-reports
failure  add-trivy-for-container-scanning
failure  fix-worker-oidc-creds
failure  monitoring-uncaught-exceptions
failure  fix/pr-preview-cleanup-race
```

## Why it fails

```
failed to determine base repo: failed to run git: fatal: not a git repository
```

The step calls `gh run list` / `gh run cancel`, but the job never checks the repository out, so `gh` has no git remote to infer the repo from. `pr-preview.yml` already passes `--repo "$GITHUB_REPOSITORY"` everywhere for exactly this reason; `pr-cleanup.yml` is the one that does not. (The `gh api` calls in the last step use absolute `/orgs/...` paths and were never affected.)

## Two further holes in the same step

Both are in the code that is supposed to prevent a cancelled-but-still-starting preview run from re-creating the deployment right after cleanup — i.e. the race this step exists for:

- **The drain loop only waited on `in_progress`.** A run still `queued` counted as drained, so it could start its deploy step immediately after the cleanup finished. It now waits on `queued` as well.
- **A failing `gh` read as "nothing running".** The loop counted zero active runs and proceeded silently. It now emits a `::warning::` instead. The listing deliberately avoids `for ... done | sort`: there the loop body runs in a subshell, so a failing `gh` cannot fail the function — which is how the first version of this fix still swallowed the error.

The step also becomes `continue-on-error: true`, consistent with the two cleanup steps below it. It runs first, so failing hard means nothing gets cleaned up at all, and the step already proceeds after its own 150s cancel timeout — a transient API error should not be treated more harshly than that.

## Verification

The workflow cannot be exercised without closing a PR, so the shell logic was run against a mocked `gh` under `bash -e`, covering:

| Scenario | Cancels | Warning | Exit |
| --- | --- | --- | --- |
| 2 active runs → cancelled → drained | 2 | no | 0 |
| same id in both statuses (dedup) | 1 | no | 0 |
| no active runs | 0 | no | 0 |
| `gh` fails outright | 0 | **yes** | 0 |
| run never drains (150s timeout) | 1 | **yes** | 0 |

The dedup case matters because a run can move from `queued` to `in_progress` between the two queries and come back twice; before, it was cancelled twice.

YAML parses and the step list is unchanged.
